### PR TITLE
Added button to home header for browsing ingested 'things'

### DIFF
--- a/app/views/homepage/_home_header.html.erb
+++ b/app/views/homepage/_home_header.html.erb
@@ -1,0 +1,13 @@
+<div class="home_call_action col-xs-12 col-sm-4 pull-right">
+  <div class="home_share_work">
+  <% if can?(:view_share_work, GenericFile) %>
+      <%= link_to "<i class=\"glyphicon glyphicon-upload\"></i> #{t('sufia.share_button')}".html_safe, sufia.new_generic_file_path, class: "btn btn-primary btn-lg btn-block", id: "contribute_link" %>
+  <% else %>
+    <%= link_to "<i class=\"glyphicon glyphicon-upload\"></i> #{t('browse_works')}".html_safe, catalog_index_path, class: "btn btn-primary btn-lg btn-block browse", id: "browse_link" %>
+  <% end %>
+  <p class="text-center"><a href="/terms/">Terms of Use</a></p>
+  </div><!-- /.home_share_work -->
+</div><!-- /.col-xs-3 -->
+<div class="col-xs-12 col-sm-8">
+  <%= render partial: "marketing" %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@
 
 en:
   hello: "Hello world"
+  browse_works: "Browse Uploaded Work"
   sufia:
     institution_name: "Oregon State University Libraries & Press"
     institution_name_full: "Oregon State University Libraries & Press"

--- a/spec/views/homepage/_home_header.html.erb_spec.rb
+++ b/spec/views/homepage/_home_header.html.erb_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "homepage/_home_header.html.erb" do
+  let(:user) {}
+  before do
+    sign_in(user) if user
+    stub_template("_marketing" => "marketing")
+    render
+  end
+  context "when visiting the root path as a guest/registered user" do
+    it "should display the Browse Uploaded Work button" do
+      expect(rendered).to have_content("Browse Uploaded Work")
+    end
+  end
+  context "when visiting the root path as an admin" do
+    let(:user) do
+      User.create(:username => "test", :group_list => "admin")
+    end 
+    it "should display the Browse Uploaded Work button" do
+      expect(rendered).to have_content("Share Your Work")
+      expect(rendered).not_to have_content("Browse Uploaded Work")
+    end
+  end
+  
+end


### PR DESCRIPTION
Fixes #49 Adds the button in for non admins to browse currently added 'things'. If we need to change any of the vocabulary used on the buttons, that is a quick and easy change.