### PR TITLE
Add web console config to environment

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,8 @@ module ScholarsArchive
     # config.i18n.default_locale = :de
     #
     # Web Console line for running tests
-    config.web_console.development_only = false
+    #config.web_console.development_only = false
+
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.autoload_paths += %W(#{config.root}/lib)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,8 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
+  config.web_console.development_only = false
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  config.web_console.development_only = false
+
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end


### PR DESCRIPTION
I was getting an error that saying 'undefined method web console'. I figured we didnt need it for production, so I moved the config to the test and dev environments.