### PR TITLE
Configure Geonames username in app. Geonames search working

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -84,7 +84,7 @@ Hyrax.config do |config|
 
   # Location autocomplete uses geonames to search for named regions
   # Username for connecting to geonames
-  # config.geonames_username = ''
+  config.geonames_username = 'etsdev'
 
   # Should the acceptance of the licence agreement be active (checkbox), or
   # implied when the save button is pressed? Set to true for active


### PR DESCRIPTION
Fixes #541 

Geonames is configured in the application now. Also, the Geonames credentials exist in LastPass and Geonames account is set up such that the free webapp service is working. This allows the location field to autocomplete in scholars archive.