### PR TITLE
preload legato library for non-production env

### DIFF
--- a/config/initializers/legato.rb
+++ b/config/initializers/legato.rb
@@ -1,0 +1,10 @@
+Rails.application.config.after_initialize do
+  # If Google Analytics are enabled, pre-load the models which rely on
+  # Legato::Model.extended(base) dynamic profile method generation. Non-production
+  # environments wouldn't necessarily have this eager loaded by default.
+  if Hyrax.config.analytics
+     require 'legato'
+     require 'hyrax/pageview'
+     require 'hyrax/download'
+  end
+end


### PR DESCRIPTION
fix #551 
The setting of GA profile is in config/analytics.yml on shared dir, and Google console with project_id scholarsarchive-165716