### PR TITLE
Blazegraph enabled for Scholars Archive

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem 'rubycas-client', git: 'https://github.com/osulp/rubycas-client'
 gem 'rubycas-client-rails', git: 'https://github.com/osulp/rubycas-client-rails'
 gem 'devise_cas_authenticatable'
 
+# Used for integration of Blazegraph backend and required API
+gem 'triplestore-adapter', git: 'https://github.com/osulp/triplestore-adapter'
+
 group :development do
   # Use Capistrano for deployment
   gem 'capistrano-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,8 +22,18 @@ GIT
       rubycas-client (~> 2.3.9.rc1)
 
 GIT
+  remote: https://github.com/osulp/triplestore-adapter
+  revision: 7f19f7ff9df87e52434d44ef879aac2f5e40a28d
+  specs:
+    triplestore-adapter (0.1.0)
+      json-ld
+      rdf
+      rdf-vocab
+      sparql-client
+
+GIT
   remote: https://github.com/projecthydra-labs/hyrax.git
-  revision: 6834f39f76824c6baa70f263f6f3e889b7fe1530
+  revision: 341645b031bb1eeabd5be6f75cf9f1b6d74918be
   branch: master
   specs:
     hyrax (2.0.0.alpha)
@@ -32,13 +42,12 @@ GIT
       active_fedora-noid (~> 2.0, >= 2.0.2)
       almond-rails (~> 0.1)
       awesome_nested_set (~> 3.1)
-      blacklight (~> 6.6, < 6.8.0)
+      blacklight (~> 6.9)
       blacklight-gallery (~> 0.7)
       breadcrumbs_on_rails (~> 3.0)
       browse-everything (>= 0.10.5)
       carrierwave (~> 1.0)
       clipboard-rails (~> 1.5)
-      daemons (~> 1.1)
       dry-equalizer (~> 0.2)
       dry-struct (~> 0.1)
       dry-validation (~> 0.9)
@@ -70,7 +79,6 @@ GIT
       signet
       tinymce-rails (~> 4.1)
       tinymce-rails-imageupload (~> 4.0.17.beta)
-      yaml_db (~> 0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -127,7 +135,7 @@ GEM
       activemodel (= 5.0.2)
       activesupport (= 5.0.2)
       arel (~> 7.0)
-    activerecord-import (0.18.1)
+    activerecord-import (0.18.2)
       activerecord (>= 3.2)
     activesupport (5.0.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -141,17 +149,17 @@ GEM
     almond-rails (0.1.0)
       rails (>= 4.2, < 6)
     arel (7.1.4)
-    autoprefixer-rails (6.7.7.2)
+    autoprefixer-rails (7.0.1)
       execjs
-    awesome_nested_set (3.1.2)
-      activerecord (>= 4.0.0, < 5.1)
-    aws-sdk (2.9.11)
-      aws-sdk-resources (= 2.9.11)
-    aws-sdk-core (2.9.11)
+    awesome_nested_set (3.1.3)
+      activerecord (>= 4.0.0, < 5.2)
+    aws-sdk (2.9.15)
+      aws-sdk-resources (= 2.9.15)
+    aws-sdk-core (2.9.15)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.9.11)
-      aws-sdk-core (= 2.9.11)
+    aws-sdk-resources (2.9.15)
+      aws-sdk-core (= 2.9.15)
     aws-sigv4 (1.0.0)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -159,7 +167,7 @@ GEM
       execjs (~> 2.0)
     bcrypt (3.1.11)
     bindex (0.5.0)
-    blacklight (6.7.3)
+    blacklight (6.9.0)
       bootstrap-sass (~> 3.2)
       deprecation
       globalid
@@ -182,7 +190,7 @@ GEM
       sass (>= 3.3.4)
     bootstrap_form (2.7.0)
     breadcrumbs_on_rails (3.0.1)
-    browse-everything (0.12.0)
+    browse-everything (0.13.0)
       addressable (~> 2.5)
       aws-sdk
       bootstrap-sass
@@ -222,7 +230,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    carrierwave (1.0.0)
+    carrierwave (1.1.0)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
@@ -237,7 +245,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
-    coveralls (0.8.20)
+    coveralls (0.8.21)
       json (>= 1.8, < 3)
       simplecov (~> 0.14.1)
       term-ansicolor (~> 1.3)
@@ -257,7 +265,7 @@ GEM
       railties (>= 4.1.0, < 5.1)
       responders
       warden (~> 1.2.3)
-    devise-guests (0.5.0)
+    devise-guests (0.6.0)
       devise
     devise_cas_authenticatable (1.9.2)
       devise (>= 1.2.0)
@@ -266,24 +274,25 @@ GEM
     docile (1.1.5)
     dropbox-sdk (1.6.5)
       json
-    dry-configurable (0.6.2)
+    dry-configurable (0.7.0)
       concurrent-ruby (~> 1.0)
     dry-container (0.6.0)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.2.4)
+    dry-core (0.3.0)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.2.0)
     dry-logic (0.4.1)
       dry-container (~> 0.2, >= 0.2.6)
       dry-core (~> 0.2)
       dry-equalizer (~> 0.2)
-    dry-struct (0.2.1)
+    dry-struct (0.3.0)
       dry-configurable (~> 0.1)
+      dry-core (~> 0.3)
       dry-equalizer (~> 0.2)
       dry-types (~> 0.9, >= 0.9.0)
       ice_nine (~> 0.11)
-    dry-types (0.9.4)
+    dry-types (0.10.3)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1)
       dry-container (~> 0.3)
@@ -291,7 +300,7 @@ GEM
       dry-equalizer (~> 0.2)
       dry-logic (~> 0.4, >= 0.4.0)
       inflecto (~> 0.0.0, >= 0.0.2)
-    dry-validation (0.10.5)
+    dry-validation (0.10.6)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
       dry-core (~> 0.2, >= 0.2.1)
@@ -312,11 +321,11 @@ GEM
       activesupport (>= 4.0)
     flot-rails (0.0.7)
       jquery-rails
-    font-awesome-rails (4.7.0.1)
-      railties (>= 3.2, < 5.1)
+    font-awesome-rails (4.7.0.2)
+      railties (>= 3.2, < 5.2)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
-    google-api-client (0.11.1)
+    google-api-client (0.11.2)
       addressable (>= 2.5.1)
       googleauth (~> 0.5)
       httpclient (>= 2.8.1, < 3.0)
@@ -339,7 +348,7 @@ GEM
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
-    hashdiff (0.3.2)
+    hashdiff (0.3.4)
     hiredis (0.6.1)
     htmlentities (4.3.4)
     httmultiparty (0.3.16)
@@ -366,7 +375,7 @@ GEM
       deprecation
       mime-types (> 2.0, < 4.0)
       mini_magick (>= 3.2, < 5)
-    hydra-editor (3.2.0)
+    hydra-editor (3.3.1)
       active-fedora (>= 9.0.0)
       almond-rails (~> 0.1)
       cancancan (~> 1.8)
@@ -410,9 +419,9 @@ GEM
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     json (2.1.0)
-    json-ld (2.1.2)
+    json-ld (2.1.3)
       multi_json (~> 1.12)
-      rdf (~> 2.1)
+      rdf (~> 2.2)
     json-schema (2.8.0)
       addressable (>= 2.4)
     jwt (1.5.6)
@@ -452,7 +461,7 @@ GEM
       multi_json (~> 1.10)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.4)
+    mail (2.6.5)
       mime-types (>= 1.16, < 4)
     mailboxer (0.14.0)
       carrierwave (>= 0.5.8)
@@ -472,6 +481,7 @@ GEM
     mysql2 (0.3.21)
     nest (2.1.0)
       redic
+    net-http-persistent (2.9.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
@@ -503,14 +513,15 @@ GEM
     power_converter (0.1.2)
     public_suffix (2.0.5)
     puma (3.8.2)
-    qa (1.0.0)
+    qa (1.1.0)
       activerecord-import
       deprecation
       faraday
       nokogiri (~> 1.6)
       rails (>= 4.2.0, < 6.0)
-    rack (2.0.1)
-    rack-protection (1.5.3)
+      rdf
+    rack (2.0.2)
+    rack-protection (2.0.0)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -579,32 +590,33 @@ GEM
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
-    responders (2.3.0)
-      railties (>= 4.2.0, < 5.1)
-    retriable (3.0.1)
+    responders (2.4.0)
+      actionpack (>= 4.2.0, < 5.3)
+      railties (>= 4.2.0, < 5.3)
+    retriable (3.0.2)
     rsolr (1.1.2)
       builder (>= 2.1.2)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.4)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
+      rspec-support (~> 3.6.0)
+    rspec-mocks (3.6.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-rails (3.5.2)
+      rspec-support (~> 3.6.0)
+    rspec-rails (3.6.0)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
@@ -625,11 +637,11 @@ GEM
       tilt (>= 1.1, < 3)
     select2-rails (3.5.10)
       thor (~> 0.14)
-    sidekiq (4.2.10)
+    sidekiq (5.0.0)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
-      redis (~> 3.2, >= 3.2.1)
+      redis (~> 3.3, >= 3.3.3)
     signet (0.7.3)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -648,8 +660,8 @@ GEM
       httmultiparty
       httparty (>= 0.11.0)
       oauth2 (>= 0.9.2)
-    slop (4.4.1)
-    solr_wrapper (0.23.0)
+    slop (4.4.3)
+    solr_wrapper (1.0.0)
       faraday
       ruby-progressbar
       rubyzip
@@ -659,6 +671,9 @@ GEM
       nokogiri
       stomp
       xml-simple
+    sparql-client (2.1.0)
+      net-http-persistent (~> 2.9)
+      rdf (~> 2.0)
     spring (2.0.1)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -688,14 +703,14 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.7)
     tins (1.13.2)
-    tinymce-rails (4.5.6)
+    tinymce-rails (4.6.0)
       railties (>= 3.1.1)
-    tinymce-rails-imageupload (4.0.17.beta.2)
+    tinymce-rails-imageupload (4.0.17.beta.3)
       railties (>= 3.2, < 6)
       tinymce-rails (~> 4.0)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
-    turbolinks-source (5.0.0)
+    turbolinks-source (5.0.3)
     twitter-typeahead-rails (0.11.1.pre.corejavascript)
       actionpack (>= 3.1)
       jquery-rails
@@ -722,9 +737,6 @@ GEM
     xml-simple (1.1.5)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    yaml_db (0.5.0)
-      rails (>= 3.0, < 5.1)
-      rake (>= 0.8.7)
 
 PLATFORMS
   ruby
@@ -769,6 +781,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
+  triplestore-adapter!
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/forms/hyrax/default_work_form.rb
+++ b/app/forms/hyrax/default_work_form.rb
@@ -2,6 +2,7 @@
 #  `rails generate hyrax:work DefaultWork`
 module Hyrax
   class DefaultWorkForm < Hyrax::Forms::WorkForm
+    include ::ScholarsArchive::TriplePoweredProperties::TriplePoweredForm
     self.model_class = ::DefaultWork
     self.terms += [:resource_type, :date_available, :date_copyright, :date_issued, :date_collected, :date_valid, :date_accepted]
 

--- a/app/models/default_work.rb
+++ b/app/models/default_work.rb
@@ -3,6 +3,7 @@
 class DefaultWork < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include ::ScholarsArchive::DefaultMetadata
+  include ScholarsArchive::TriplePoweredProperties::WorkBehavior
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -1,8 +1,10 @@
 # Generated via
 #  `rails generate hyrax:work Etd`
 class Etd < ActiveFedora::Base
+
   include ::Hyrax::WorkBehavior
   include ::ScholarsArchive::DefaultMetadata
+  include ScholarsArchive::TriplePoweredProperties::WorkBehavior
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,8 @@ require_relative 'boot'
 
 require 'rails/all'
 require 'edtf'
+require 'triplestore_adapter'
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
@@ -23,6 +25,7 @@ module ScholarsArchive
 
     config.time_zone = 'Pacific Time (US & Canada)'
     config.active_job.queue_adapter = :inline
+    config.autoload_paths += %W(#{config.root}/lib)
 
     # load and inject local_env.yml key/values into ENV
     config.before_configuration do

--- a/config/triplestore_adapter/blazegraph/blazegraph.properties
+++ b/config/triplestore_adapter/blazegraph/blazegraph.properties
@@ -1,0 +1,46 @@
+#
+# Note: These options are applied when the journal and the triple store are
+# first created.
+
+##
+## Journal options.
+##
+
+# The backing file. This contains all your data.  You want to put this someplace
+# safe.  The default locator will wind up in the directory from which you start
+# your servlet container.
+com.bigdata.journal.AbstractJournal.file=blazegraph/blazegraph.jnl
+
+# The persistence engine.  Use 'Disk' for the WORM or 'DiskRW' for the RWStore.
+com.bigdata.journal.AbstractJournal.bufferMode=DiskRW
+
+# Setup for the RWStore recycler rather than session protection.
+#com.bigdata.service.AbstractTransactionService.minReleaseAge=1
+
+#com.bigdata.btree.writeRetentionQueue.capacity=4000
+#com.bigdata.btree.BTree.branchingFactor=128
+
+# 200M initial extent.
+#com.bigdata.journal.AbstractJournal.initialExtent=209715200
+#com.bigdata.journal.AbstractJournal.maximumExtent=209715200
+
+##
+## Setup for QUADS mode without the full text index.
+##
+#com.bigdata.rdf.sail.truthMaintenance=false
+#com.bigdata.rdf.store.AbstractTripleStore.quads=false
+#com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers=false
+#com.bigdata.rdf.store.AbstractTripleStore.textIndex=true
+#com.bigdata.rdf.store.AbstractTripleStore.axiomsClass=com.bigdata.rdf.axioms.NoAxioms
+
+# Bump up the branching factor for the lexicon indices on the default kb.
+#com.bigdata.namespace.kb.lex.com.bigdata.btree.BTree.branchingFactor=400
+
+# Bump up the branching factor for the statement indices on the default kb.
+#com.bigdata.namespace.kb.spo.com.bigdata.btree.BTree.branchingFactor=1024
+
+# Disable stopwords in text search; bad for term completion
+#com.bigdata.search.FullTextIndex.analyzerFactoryClass=com.bigdata.search.ConfigurableAnalyzerFactory
+#com.bigdata.search.ConfigurableAnalyzerFactory.analyzer.eng.analyzerClass=org.apache.lucene.analysis.standard.StandardAnalyzer
+#com.bigdata.search.ConfigurableAnalyzerFactory.analyzer.eng.stopwords=none
+#com.bigdata.search.ConfigurableAnalyzerFactory.analyzer._.like=eng

--- a/config/triplestore_adapter/blazegraph/log4j.properties
+++ b/config/triplestore_adapter/blazegraph/log4j.properties
@@ -1,0 +1,121 @@
+# Default log4j configuration. See the individual classes for the
+# specific loggers, but generally they are named for the class in
+# which they are defined.
+
+# Default log4j configuration for testing purposes.
+#
+# You probably want to set the default log level to ERROR.
+#
+log4j.rootCategory=INFO, error
+#log4j.rootCategory=WARN, dest1
+#log4j.rootCategory=WARN, dest2
+
+# Loggers.
+# Note: logging here at INFO or DEBUG will significantly impact throughput!
+log4j.logger.com.bigdata=WARN
+log4j.logger.com.bigdata.btree=WARN
+
+# Normal data loader (single threaded).
+#log4j.logger.com.bigdata.rdf.store.DataLoader=INFO
+
+#error
+log4j.appender.error=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.error.File=log/blazegraph.log
+log4j.appender.error.DatePattern='.'yyyy-MM-dd
+log4j.appender.error.layout=org.apache.log4j.PatternLayout
+log4j.appender.error.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%p] %c:%L - %m%n
+
+# dest1
+log4j.appender.dest1=org.apache.log4j.ConsoleAppender
+log4j.appender.dest1.layout=org.apache.log4j.PatternLayout
+log4j.appender.dest1.layout.ConversionPattern=%-5p: %F:%L: %m%n
+#log4j.appender.dest1.layout.ConversionPattern=%-5p: %r %l: %m%n
+#log4j.appender.dest1.layout.ConversionPattern=%-5p: %m%n
+#log4j.appender.dest1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+#log4j.appender.dest1.layout.ConversionPattern=%-4r(%d) [%t] %-5p %c(%l:%M) %x - %m%n
+
+# dest2 includes the thread name and elapsed milliseconds.
+# Note: %r is elapsed milliseconds.
+# Note: %t is the thread name.
+# See http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html
+log4j.appender.dest2=org.apache.log4j.ConsoleAppender
+log4j.appender.dest2.layout=org.apache.log4j.PatternLayout
+log4j.appender.dest2.layout.ConversionPattern=%-5p: %r %X{hostname} %X{serviceUUID} %X{taskname} %X{timestamp} %X{resources} %t %l: %m%n
+
+##
+# Rule execution log. This is a formatted log file (comma delimited).
+log4j.logger.com.bigdata.relation.rule.eval.RuleLog=INFO,ruleLog
+log4j.additivity.com.bigdata.relation.rule.eval.RuleLog=false
+log4j.appender.ruleLog=org.apache.log4j.FileAppender
+log4j.appender.ruleLog.Threshold=ALL
+log4j.appender.ruleLog.File=log/rules.log
+log4j.appender.ruleLog.Append=true
+# I find that it is nicer to have this unbuffered since you can see what
+# is going on and to make sure that I have complete rule evaluation logs
+# on shutdown.
+log4j.appender.ruleLog.BufferedIO=false
+log4j.appender.ruleLog.layout=org.apache.log4j.PatternLayout
+log4j.appender.ruleLog.layout.ConversionPattern=%m
+
+##
+# Summary query evaluation log (tab delimited file). Uncomment the next line to enable.
+#log4j.logger.com.bigdata.bop.engine.QueryLog=INFO,queryLog
+log4j.additivity.com.bigdata.bop.engine.QueryLog=false
+log4j.appender.queryLog=org.apache.log4j.FileAppender
+log4j.appender.queryLog.Threshold=ALL
+log4j.appender.queryLog.File=log/queryLog.csv
+log4j.appender.queryLog.Append=true
+# I find that it is nicer to have this unbuffered since you can see what
+# is going on and to make sure that I have complete rule evaluation logs
+# on shutdown.
+log4j.appender.queryLog.BufferedIO=false
+log4j.appender.queryLog.layout=org.apache.log4j.PatternLayout
+log4j.appender.queryLog.layout.ConversionPattern=%m
+
+##
+# BOp run state trace (tab delimited file).  Uncomment the next line to enable.
+#log4j.logger.com.bigdata.bop.engine.RunState$TableLog=INFO,queryRunStateLog
+log4j.additivity.com.bigdata.bop.engine.RunState$TableLog=false
+log4j.appender.queryRunStateLog=org.apache.log4j.FileAppender
+log4j.appender.queryRunStateLog.Threshold=ALL
+log4j.appender.queryRunStateLog.File=log/queryRunState.log
+log4j.appender.queryRunStateLog.Append=true
+# I find that it is nicer to have this unbuffered since you can see what
+# is going on and to make sure that I have complete rule evaluation logs
+# on shutdown.
+log4j.appender.queryRunStateLog.BufferedIO=false
+log4j.appender.queryRunStateLog.layout=org.apache.log4j.PatternLayout
+log4j.appender.queryRunStateLog.layout.ConversionPattern=%m
+
+##
+# Solutions trace (tab delimited file).  Uncomment the next line to enable.
+#log4j.logger.com.bigdata.bop.engine.SolutionsLog=INFO,solutionsLog
+log4j.additivity.com.bigdata.bop.engine.SolutionsLog=false
+log4j.appender.solutionsLog=org.apache.log4j.ConsoleAppender
+#log4j.appender.solutionsLog=org.apache.log4j.FileAppender
+log4j.appender.solutionsLog.Threshold=ALL
+log4j.appender.solutionsLog.File=log/solutions.csv
+log4j.appender.solutionsLog.Append=true
+# I find that it is nicer to have this unbuffered since you can see what
+# is going on and to make sure that I have complete rule evaluation logs
+# on shutdown.
+log4j.appender.solutionsLog.BufferedIO=false
+log4j.appender.solutionsLog.layout=org.apache.log4j.PatternLayout
+log4j.appender.solutionsLog.layout.ConversionPattern=SOLUTION:\t%m
+
+##
+# SPARQL query trace (plain text file).  Uncomment 2nd line to enable.
+log4j.logger.com.bigdata.rdf.sparql.ast.eval.ASTEvalHelper=WARN
+#log4j.logger.com.bigdata.rdf.sparql.ast.eval.ASTEvalHelper=INFO,sparqlLog
+log4j.additivity.com.bigdata.rdf.sparql.ast.eval.ASTEvalHelper=false
+log4j.appender.sparqlLog=org.apache.log4j.ConsoleAppender
+#log4j.appender.sparqlLog=org.apache.log4j.FileAppender
+log4j.appender.sparqlLog.Threshold=ALL
+log4j.appender.sparqlLog.File=log/sparql.txt
+log4j.appender.sparqlLog.Append=true
+# I find that it is nicer to have this unbuffered since you can see what
+# is going on and to make sure that I have complete rule evaluation logs
+# on shutdown.
+log4j.appender.sparqlLog.BufferedIO=false
+log4j.appender.sparqlLog.layout=org.apache.log4j.PatternLayout
+log4j.appender.sparqlLog.layout.ConversionPattern=#----------%d-----------tx=%X{tx}\n%m\n

--- a/lib/scholars_archive/triple_powered_properties/errors.rb
+++ b/lib/scholars_archive/triple_powered_properties/errors.rb
@@ -1,0 +1,14 @@
+module ScholarsArchive::TriplePoweredProperties
+  module Errors
+
+    ##
+    # Base error
+    class TriplePoweredPropertyError < StandardError
+    end
+
+    ##
+    # Invalid URL
+    class InvalidUrlError < TriplePoweredPropertyError
+    end
+  end
+end

--- a/lib/scholars_archive/triple_powered_properties/has_url_validator.rb
+++ b/lib/scholars_archive/triple_powered_properties/has_url_validator.rb
@@ -1,0 +1,26 @@
+require 'uri'
+
+module ScholarsArchive::TriplePoweredProperties
+  class HasUrlValidator < ActiveModel::Validator
+
+    ##
+    # Evaluate each triple powered property value to ensure it is a valid URL
+    #
+    # @param record [ActiveModel] the model being validated
+    def validate(record)
+      return if record.triple_powered_properties.empty?
+
+      record.triple_powered_properties.each do |prop|
+        record[prop].each do |value|
+          begin
+            uri = URI.parse(value)
+          rescue
+            record.errors[prop] << "#{value} is not a URL"
+          else
+            record.errors[prop] << "#{value} is invalid" unless uri.kind_of?(URI::HTTP)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/scholars_archive/triple_powered_properties/inputs/triple_powered_property_input.rb
+++ b/lib/scholars_archive/triple_powered_properties/inputs/triple_powered_property_input.rb
@@ -1,0 +1,182 @@
+module ScholarsArchive::TriplePoweredProperties::Inputs
+
+  ##
+  # Levered hydra-editors multi_value input field to handle triple powered properties label fetching
+  # and rendering
+  class TriplePoweredPropertyInput < SimpleForm::Inputs::CollectionInput
+
+    ##
+    # Render the input field as a multi_value or single field
+    #
+    # @param wrapper_options [Hash] the hash supplied by the partial
+    def input(wrapper_options)
+      @rendered_first_element = false
+      input_html_classes.unshift('string')
+      input_html_options[:name] ||= "#{object_name}[#{attribute_name}][]"
+
+      # ensure the multi_value class is included if it was provided as part of the options
+      input_options[:wrapper_html] ||= { class: '' }
+      input_options[:wrapper_html][:class] += input_options[:multi_value] ? ' multi_value' : ''
+
+      # Render the multiple or a single field for this TriplePoweredPropertyInput
+      input_options[:multi_value] ? render_multi : render_field(collection.first, 0)
+    end
+
+    protected
+
+    ##
+    # Renders a single field
+    #
+    # @param value [String] the value of the property
+    # @param index [Integer] the index of the field being rendered
+    def render_field(value, index)
+      html = build_field(value, index)
+      html += build_label(value)
+      html += "<div class='message has-warning hidden'></div>".html_safe
+      html
+    end
+
+    ##
+    # Wraps a collection of single fields in a UL
+    def render_multi
+      outer_wrapper do
+        buffer_each(collection) do |value, index|
+          inner_wrapper do
+            render_field(value, index)
+          end
+        end
+      end
+    end
+
+    def buffer_each(collection)
+      collection.each_with_object('').with_index do |(value, buffer), index|
+        buffer << yield(value, index)
+      end
+    end
+
+    ##
+    # The outer UL wrapping a list of fields
+    def outer_wrapper
+      "    <ul class=\"listing\">\n        #{yield}\n      </ul>\n"
+    end
+
+    ##
+    # The LI wrapping each individual field
+    def inner_wrapper
+      <<-HTML
+          <li class="field-wrapper">
+            #{yield}
+          </li>
+      HTML
+    end
+
+    private
+
+    ##
+    # Although the 'index' parameter is not used in this implementation it is useful in an
+    # an overridden version of this method, especially when the field is a complex object and
+    # the override defines nested fields.
+    def build_field_options(value, index)
+      options = input_html_options.dup
+
+      options[:value] = value
+      if @rendered_first_element
+        options[:id] = nil
+        options[:required] = nil
+      else
+        options[:id] ||= input_dom_id
+      end
+      options[:class] ||= []
+      options[:class] += ["#{input_dom_id} form-control multi-text-field"]
+      options[:'aria-labelledby'] = label_id
+      @rendered_first_element = true
+
+      options
+    end
+
+    ##
+    # ActionView builds the appropriate TEXTAREA or INPUT nodes
+    #
+    # @param value [String] the property value
+    # @param index [Integer] the index of this property value
+    def build_field(value, index)
+      options = build_field_options(value, index)
+      if options.delete(:type) == 'textarea'.freeze
+        @builder.text_area(attribute_name, options)
+      else
+        @builder.text_field(attribute_name, options)
+      end
+    end
+
+    ##
+    # Build the triple powered property label interface with the preferred label displayed and a collapsable list
+    # containing the remaining labels.
+    #
+    # The labels include microdata for search engines
+    #
+    # @param uri [String] the uri to the RDF resource containing the labels
+    def build_label(uri)
+      return "<div itemscope itemtype='' class='triple_powered_labels hidden' data-rdf-uri=''></div>".html_safe if uri.blank?
+
+      begin
+        graph = ScholarsArchive::TriplePoweredProperties::Triplestore.fetch(uri)
+        predicate_labels = ScholarsArchive::TriplePoweredProperties::Triplestore.predicate_labels(graph)
+      rescue TriplestoreAdapter::TriplestoreException => e
+        return "<div class='triple_powered_labels'><span class='error'>Failed to fetch labels for this URL.</span></div>".html_safe
+      end
+
+      "<div itemscope itemtype='#{uri}' class='triple_powered_labels' data-rdf-uri='#{uri}'>#{build_label_list(predicate_labels, uri)}</div>".html_safe
+    end
+
+    ##
+    # Iterate through each of the predicate_labels and generate a SPAN for each
+    #
+    # @param predicate_labels [Hash] the predicate and each of the labels
+    # @param uri [String] the RDF endpoint containing the labels
+    def build_label_list(predicate_labels, uri)
+      count = predicate_labels.values.flatten.size
+      return "<span itemprop='uri'>#{uri}</span>" if count == 0
+
+      spans = []
+      predicate_labels.each_pair { |k, v|
+        spans << v.map { |label| "<span itemtype='#{k}' itemprop='label'>#{label}</span>" }
+      }
+      spans.flatten!
+
+      first_span = spans.delete_at(0)
+      return first_span if spans.size == 0
+
+      <<-HTML
+        <span class='toggle badge'
+          data-show-all="Show all labels. (#{count})"
+          data-hide-all="Hide labels.">Show all labels. (#{count})</span>
+        #{first_span}
+        <ul class='list'>
+          <li>
+            #{spans.join('</li><li>')}
+          </li>
+        </ul>
+      HTML
+    end
+
+    ##
+    # Create an id
+    def label_id
+      input_dom_id + '_label'
+    end
+
+    ##
+    # Create a dom id
+    def input_dom_id
+      input_html_options[:id] || "#{object_name}_#{attribute_name}"
+    end
+
+    def collection
+      @collection ||= Array.wrap(object[attribute_name]).reject { |value| value.to_s.strip.blank? } + ['']
+    end
+
+    def multiple?;
+      true;
+    end
+  end
+end

--- a/lib/scholars_archive/triple_powered_properties/triple_powered_form.rb
+++ b/lib/scholars_archive/triple_powered_properties/triple_powered_form.rb
@@ -1,0 +1,12 @@
+module ScholarsArchive::TriplePoweredProperties
+  module TriplePoweredForm
+
+    ##
+    # Checks the model of this form to evaluate if a property is triple powered
+    # @param property [Symbol] the models property to be evaluated
+    # @return [Boolean] true if the models triple_powered_properties includes the property
+    def has_triple_powered_property?(property)
+      self.model.triple_powered_properties.include?(property)
+    end
+  end
+end

--- a/lib/scholars_archive/triple_powered_properties/triplestore.rb
+++ b/lib/scholars_archive/triple_powered_properties/triplestore.rb
@@ -1,0 +1,52 @@
+require 'triplestore_adapter'
+
+module ScholarsArchive::TriplePoweredProperties
+  class Triplestore
+    ##
+    # Query the graph found at the supplied uri
+    #
+    # @param uri [String] the uri for the graph
+    # @return [RDF::Graph] the graph
+    def self.fetch(uri)
+      unless uri.blank?
+        begin
+          @triplestore ||= TriplestoreAdapter::Triplestore.new(TriplestoreAdapter::Client.new(ENV["SCHOLARSARCHIVE_TRIPLESTORE_ADAPTER_TYPE"] || "blazegraph",
+                                                      ENV["SCHOLARSARCHIVE_TRIPLESTORE_ADAPTER_URL"] || 'http://localhost:9999/blazegraph/namespace/development/sparql'))
+          @triplestore.fetch(uri, from_remote: true)
+        rescue TriplestoreAdapter::TriplestoreException => e
+          raise e
+        end
+      end
+    end
+
+    ##
+    # Common predicates which represent labels in a graph
+    def self.rdf_label_predicates
+      [RDF::Vocab::SKOS.prefLabel,
+       RDF::Vocab::DC.title,
+       RDF::Vocab::RDFS.label,
+       RDF::Vocab::SKOS.altLabel,
+       RDF::Vocab::SKOS.hiddenLabel]
+    end
+
+    ##
+    # Returns an array of the labels found in the supplied graph
+    #
+    # @param graph [RDF::Graph] the graph
+    # @return [Hash<String,Array<String>>] the labels
+    def self.predicate_labels(graph)
+      labels = {}
+      return labels if graph.nil?
+
+      self.rdf_label_predicates.each do |predicate|
+        labels[predicate.to_s] = []
+        labels[predicate.to_s] << graph
+                    .query(predicate: predicate)
+                    .select { |statement| !statement.is_a?(Array) }
+                    .map { |statement| statement.object.to_s }
+        labels[predicate.to_s].flatten!.compact!
+      end
+      labels
+    end
+  end
+end

--- a/lib/scholars_archive/triple_powered_properties/work_behavior.rb
+++ b/lib/scholars_archive/triple_powered_properties/work_behavior.rb
@@ -1,0 +1,88 @@
+module ScholarsArchive::TriplePoweredProperties
+  module WorkBehavior
+    extend ActiveSupport::Concern
+
+    included do
+
+      # store the triple powered property labels in SOLR
+      self.indexer = ScholarsArchive::TriplePoweredProperties::WorkIndexer
+
+      # server side validation for triple powered property values being valid urls
+      self.validates_with ScholarsArchive::TriplePoweredProperties::HasUrlValidator
+
+      class_attribute :triple_powered_properties
+
+      # fetch the graphs and store them in the triple store cache before saving the work
+      before_save :fetch_graphs
+
+      def triple_powered_properties
+        [:based_near]
+      end
+    end
+
+    ##
+    # Queries the labels for each graph associated with the triple powered property
+    #
+    # @param key [Symbol] the property uri with associated graphs
+    # @return [Hash<String,Array<String>>] a hash keyed on the URI with its labels as the value
+    def uri_labels(property)
+      labels = {}
+
+      return labels if uri_graphs.nil?
+      return labels if uri_graphs[property].nil?
+
+      uri_graphs[property].each do |h|
+        result = h[:result]
+        uri = h[:uri]
+        labels[uri] = []
+        if result.is_a?(String)
+          labels[uri] << result
+        else
+          labels[uri] << ScholarsArchive::TriplePoweredProperties::Triplestore.predicate_labels(result).values.flatten.compact
+        end
+      end
+      labels
+    end
+
+    def uri_graphs
+      @uri_graphs ||= build_uri_graphs
+    end
+
+    private
+
+    ##
+    # Connect to the triplestore backend, and fetch the graphs
+    def fetch_graphs
+      uri_graphs
+    end
+
+    ##
+    # Build a hash, keyed on the property symbol, of graphs related to each triple powered property
+    def build_uri_graphs
+      graphs = {}
+      # iterate through each of the properties having RDF URIs and fetch the graphs from the triplestore
+      self.triple_powered_properties.each do |property|
+        graphs[property] = fetch(property)
+      end
+      graphs
+    end
+
+    ##
+    # Fetch the graphs for each URI value set on the property
+    # @param [Symbol] the property which is triple powered
+    # @return [Array<String>] the array of graphs for each URI value in the property
+    #                         OR the original URI if fetching the graphs fails (invalid URI, for instance)
+    def fetch(property)
+      # iterate through each of the uri's stored in the property of this model
+      self[property].map do |uri|
+        begin
+          # Fetch the graph from the triplestore, or return the uri
+          graph = ScholarsArchive::TriplePoweredProperties::Triplestore.fetch(uri)
+          { uri: uri, result: graph }
+        rescue TriplestoreAdapter::TriplestoreException
+          { uri: uri, result: uri }
+        end
+      end
+    end
+  end
+end

--- a/lib/scholars_archive/triple_powered_properties/work_indexer.rb
+++ b/lib/scholars_archive/triple_powered_properties/work_indexer.rb
@@ -1,0 +1,17 @@
+module ScholarsArchive::TriplePoweredProperties
+  class WorkIndexer < Hyrax::WorkIndexer
+
+    ##
+    # Iterate through each of the triple powered properties to store its labels in solr
+    def generate_solr_document
+      super.tap do |solr_doc|
+        unless self.object.triple_powered_properties.nil?
+          self.object.triple_powered_properties.each do |p|
+            labels = self.object.uri_labels(p).values.flatten.compact
+            solr_doc[Solrizer.solr_name(p.to_s)] = labels
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ require 'rspec/rails'
 require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
 
+require 'triplestore_adapter'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/scholars_archive/triple_powered_properties/triple_powered_form_spec.rb
+++ b/spec/scholars_archive/triple_powered_properties/triple_powered_form_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe ScholarsArchive::TriplePoweredProperties::TriplePoweredForm do
+  describe "#has_triple_powered_property?" do
+    let(:form) { Hyrax::DefaultWorkForm.new(DefaultWork.new({ based_near: [ url ], title: ['TestTest'] }), instance_double("Ability"), instance_double("Controller")) }
+    let(:url) { 'http://opaquenamespace.org/ns/TestVocabulary/TestTerm' }
+    it "should return a truthy statement if it has a triple powered property" do
+      expect(form.has_triple_powered_property?(:based_near)).to eq true
+    end
+    it "should return a falsey statement if it does not have a triple powered property" do
+      expect(form.has_triple_powered_property?(:anything_else)).to eq false
+    end
+  end
+end

--- a/spec/scholars_archive/triple_powered_properties/triplestore_spec.rb
+++ b/spec/scholars_archive/triple_powered_properties/triplestore_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe ScholarsArchive::TriplePoweredProperties::Triplestore do
+
+
+  let(:triplestore) { described_class }
+  let(:label) {"Blah"}
+
+  describe "#fetch" do
+    before do
+      allow_any_instance_of(TriplestoreAdapter::Triplestore).to receive(:fetch).with("http://opaquenamespace.org/ns/blah", {:from_remote=>true}).and_return("blah")
+    end
+    it "should set the triplestore as an instance of TriplestoreAdapter::Triplestore" do
+      triplestore.fetch("http://opaquenamespace.org/ns/blah")
+      expect(triplestore.instance_variable_get(:@triplestore)).to be_kind_of TriplestoreAdapter::Triplestore
+    end
+  end
+
+  describe "#rdf_label_predicates" do
+    it "should return an array of predicates" do
+      expect(triplestore.rdf_label_predicates).to be_kind_of Array
+      expect(triplestore.rdf_label_predicates).to eq [RDF::Vocab::SKOS.prefLabel,
+                                                      RDF::Vocab::DC.title,
+                                                      RDF::Vocab::RDFS.label,
+                                                      RDF::Vocab::SKOS.altLabel,
+                                                      RDF::Vocab::SKOS.hiddenLabel]
+    end
+  end
+
+  describe "#predicate_labels" do
+    it "should return an hash of labels" do
+      expect(triplestore.predicate_labels(build_graph)).to eq({"http://purl.org/dc/terms/title" => [],
+                                                               "http://www.w3.org/2000/01/rdf-schema#label" => ["Blah"],
+                                                               "http://www.w3.org/2004/02/skos/core#altLabel" => [],
+                                                               "http://www.w3.org/2004/02/skos/core#hiddenLabel" => [],
+                                                               "http://www.w3.org/2004/02/skos/core#prefLabel" => []})
+    end
+  end
+end
+
+def build_graph
+  graph = RDF::Graph.new
+  graph << RDF::Statement.new(RDF::URI.new('http://opaquenamespace.org/ns/TestVocabulary/TestTerm'), RDF::Vocab::RDFS.label, label)
+  graph
+end
+

--- a/spec/scholars_archive/triple_powered_properties/work_behavior_spec.rb
+++ b/spec/scholars_archive/triple_powered_properties/work_behavior_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe ScholarsArchive::TriplePoweredProperties::WorkBehavior do
+  let(:url) { 'http://opaquenamespace.org/ns/TestVocabulary/TestTerm' }
+  subject { DefaultWork.new({ based_near: [ url ], title: ['TestTest'] }) }
+  let(:label) { 'hello' }
+
+  before do
+    allow(subject).to receive(:uri_graphs).and_return({:based_near=>[{:uri=>url, :result=>build_graph}]})
+  end
+
+  describe '#uri_labels' do
+    it 'should have triple powered properties with labels' do
+      expect(subject.triple_powered_properties).to be_a_kind_of(Array)
+      expect(subject.uri_labels(:based_near)[url]).to be_a_kind_of(Array)
+      #TODO Check to see if we want this actually nested arrays... [[]]
+      expect(subject.uri_labels(:based_near)[url].flatten).to include(label)
+    end
+  end
+end
+
+def build_graph
+  graph = RDF::Graph.new
+  graph << RDF::Statement.new(RDF::URI.new('http://opaquenamespace.org/ns/TestVocabulary/TestTerm'), RDF::Vocab::RDFS.label, label)
+  graph
+end
+

--- a/spec/scholars_archive/triple_powered_properties/work_indexer_spec.rb
+++ b/spec/scholars_archive/triple_powered_properties/work_indexer_spec.rb
@@ -1,0 +1,20 @@
+
+require 'rails_helper'
+
+RSpec.describe ScholarsArchive::TriplePoweredProperties::WorkIndexer do
+  let(:url) { 'http://opaquenamespace.org/ns/TestVocabulary/TestTerm' }
+  subject(:solr_document) { service.generate_solr_document }
+  let(:service) { described_class.new(work) }
+  let(:work) { DefaultWork.new({ based_near: [ url ], title: ['TestTest'] }) }
+  let(:label) { 'hello' }
+
+  describe "#generate_solr_document" do
+    before do
+      allow(work).to receive(:fetch).and_return(["Blahbalh"])
+      allow(work).to receive(:uri_labels).and_return({:based_near => ["Blahblah"]})
+    end
+    it "Should append the labels into the solr_document" do
+      expect(solr_document["based_near_tesim"]).to eq ["Blahblah"]
+    end
+  end
+end


### PR DESCRIPTION
Fixes #552 

This adds all the necessary work to have blazegraph as a triplestore backend. It fetches and caches and accepts URI's and indexes the labels in solr.