### PR TITLE
added other input for degree_field and degree_level select

### DIFF
--- a/app/actors/scholars_archive/actors/add_other_field_option_actor.rb
+++ b/app/actors/scholars_archive/actors/add_other_field_option_actor.rb
@@ -1,0 +1,57 @@
+module ScholarsArchive
+  module Actors
+    # The Hyrax::AddOtherFieldOptionActor responds to two primary actions:
+    # * #create
+    # * #update
+    # it must instantiate the next actor in the chain and instantiate it.
+    class AddOtherFieldOptionActor < Hyrax::Actors::BaseActor
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if create was successful
+      def create(env)
+        save_custom_option(env) && next_actor.create(env)
+      end
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if update was successful
+      def update(env)
+        update_custom_option(env) && next_actor.update(env)
+      end
+
+      private
+
+      def save_custom_option(env)
+        if env.curation_concern.degree_field_other.present?
+          OtherOption.find_or_create_by(name: env.curation_concern.degree_field_other.to_s, work_id: env.curation_concern.id, property_name: :degree_field.to_s)
+        end
+        if env.curation_concern.degree_level_other.present?
+          OtherOption.find_or_create_by(name: env.curation_concern.degree_level_other.to_s, work_id: env.curation_concern.id, property_name: :degree_level.to_s)
+        end
+      end
+
+      def update_custom_option(env)
+        if env.curation_concern.degree_field_other.present?
+          degree_field_other_option = get_other_option(env, :degree_field)
+          if degree_field_other_option.present?
+            OtherOption.update(degree_field_other_option.id, name: env.curation_concern.degree_field_other.to_s)
+          else
+            OtherOption.find_or_create_by(name: env.curation_concern.degree_field_other.to_s, work_id: env.curation_concern.id, property_name: :degree_field.to_s)
+          end
+        end
+
+        if env.curation_concern.degree_level_other.present?
+          degree_level_other_option = get_other_option(env, :degree_level)
+          if degree_level_other_option.present?
+            OtherOption.update(degree_level_other_option.id, name: env.curation_concern.degree_level_other.to_s)
+          else
+            OtherOption.find_or_create_by(name: env.curation_concern.degree_level_other.to_s, work_id: env.curation_concern.id, property_name: :degree_level.to_s)
+          end
+        end
+        return true
+      end
+
+      def get_other_option(env, field)
+        OtherOption.find_by(work_id: env.curation_concern.id, property_name: field.to_s)
+      end
+    end
+  end
+end

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
 //= require add_date_field
 //= require add_geo_field
+//= require degree_other
 //= require jquery-datetimepicker/jquery.datetimepicker.full
 //= require turbolinks//
 //= require blacklight/blacklight

--- a/app/assets/javascripts/degree_other.js.coffee
+++ b/app/assets/javascripts/degree_other.js.coffee
@@ -1,0 +1,25 @@
+jQuery ->
+  hide_field = (class_selector) ->
+    $(class_selector).addClass("hidden")
+    $(class_selector+' input').attr("type", "hidden")
+    $(class_selector+' input').addClass("hidden")
+
+  show_field = (class_selector) ->
+    $(class_selector).removeClass("hidden")
+    $(class_selector+' input').attr("type", "text")
+    $(class_selector+' input').removeClass("hidden")
+
+
+  $('select.degree-field-selector').change ->
+    selected = $('select.degree-field-selector :selected').val()
+    if selected == "Other"
+      show_field('.degree-field-other')
+    else
+      hide_field('.degree-field-other')
+
+  $('select.degree-level-selector').change ->
+    selected = $('select.degree-level-selector :selected').val()
+    if selected == "Other"
+      show_field('.degree-level-other')
+    else
+      hide_field('.degree-level-other')

--- a/app/forms/scholars_archive/etd_work_form_behavior.rb
+++ b/app/forms/scholars_archive/etd_work_form_behavior.rb
@@ -3,6 +3,8 @@ module ScholarsArchive
     extend ActiveSupport::Concern
     included do
       include ScholarsArchive::DefaultWorkFormBehavior
+      attr_accessor :degree_level_other
+      attr_accessor :degree_field_other
       self.terms += [:degree_level, :degree_name, :degree_field, :degree_grantors, :contributor_advisor, :contributor_committeemember, :graduation_year, :degree_discipline]
       self.required_fields += [:degree_level, :degree_name, :degree_field, :degree_grantors, :graduation_year]
 

--- a/app/models/concerns/scholars_archive/etd_metadata.rb
+++ b/app/models/concerns/scholars_archive/etd_metadata.rb
@@ -22,6 +22,9 @@ module ScholarsArchive
         index.as :stored_searchable, :facetable
       end
 
+      # accessor value used by AddOtherFieldOptionActor to persist "Other" values provided by the user
+      attr_accessor :degree_field_other
+
       property :degree_grantors, predicate: ::RDF::Vocab::MARCRelators.dgg, multiple: false do |index|
         index.as :stored_searchable
       end
@@ -29,6 +32,9 @@ module ScholarsArchive
       property :degree_level, predicate: ::RDF::URI.new("http://purl.org/NET/UNTL/vocabularies/degree-information/#level"), multiple: false do |index|
         index.as :stored_searchable, :facetable
       end
+
+      # accessor value used by AddOtherFieldOptionActor to persist "Other" values provided by the user
+      attr_accessor :degree_level_other
 
       property :degree_name, predicate: ::RDF::URI.new("http://purl.org/ontology/bibo/ThesisDegree"), multiple: false do |index|
         index.as :stored_searchable, :facetable

--- a/app/models/other_option.rb
+++ b/app/models/other_option.rb
@@ -1,0 +1,3 @@
+class OtherOption < ApplicationRecord
+  validates :name, :work_id, :property_name, :presence => true
+end

--- a/app/services/scholars_archive/default_middleware_stack.rb
+++ b/app/services/scholars_archive/default_middleware_stack.rb
@@ -1,0 +1,11 @@
+module ScholarsArchive
+  class DefaultMiddlewareStack < Hyrax::DefaultMiddlewareStack
+    def self.build_sa_stack
+      # insert our our custom actor after the last actor in the hyrax default middleware stack
+      sa_middlewares = build_stack.insert_after build_stack.last.klass, ScholarsArchive::Actors::AddOtherFieldOptionActor
+      sa_stack = ActionDispatch::MiddlewareStack.new
+      sa_stack.middlewares = sa_middlewares
+      sa_stack
+    end
+  end
+end

--- a/app/views/records/edit_fields/_degree_field.html.erb
+++ b/app/views/records/edit_fields/_degree_field.html.erb
@@ -2,4 +2,9 @@
 <%= f.input :degree_field,
     collection: degree_field_service.select_active_options,
     include_blank: true,
-    input_html: { class: "form-control" } %>
+    input_html: { class: "form-control degree-field-selector"} %>
+<% if f.object.model.degree_field.present? && f.object.model.degree_field == 'Other' && f.object.model.degree_field_other.present? %>
+    <%= f.input :degree_field_other, label: false, aria: { label: 'Degree Field' }, :placeholder => 'Degree Field', :input_html => {value: f.object.model.degree_field_other, :class => "form-control"}, :wrapper_html => {:class => "degree-field-other" } %>
+<% else %>
+    <%= f.input :degree_field_other, as: :hidden, label: false, aria: { label: 'Degree Field' }, :placeholder => 'Degree Field', :input_html => {:class => "form-control"}, :wrapper_html => {:class => "degree-field-other" } %>
+<% end %>

--- a/app/views/records/edit_fields/_degree_level.html.erb
+++ b/app/views/records/edit_fields/_degree_level.html.erb
@@ -2,4 +2,9 @@
 <%= f.input :degree_level,
     collection: degree_level_service.select_active_options,
     include_blank: true,
-    input_html: { class: "form-control" } %>
+    input_html: { class: "form-control degree-level-selector" } %>
+<% if f.object.model.degree_level.present? && f.object.model.degree_level == 'Other' && f.object.model.degree_level_other.present? %>
+    <%= f.input :degree_level_other, label: false, aria: { label: 'Degree Level' }, :placeholder => 'Degree Level', :input_html => {value: f.object.model.degree_level_other, :class => "form-control"}, :wrapper_html => {:class => "degree-level-other" } %>
+<% else %>
+    <%= f.input :degree_level_other, as: :hidden, label: false, aria: { label: 'Degree Level' }, :placeholder => 'Degree Level', :input_html => {:class => "form-control"}, :wrapper_html => {:class => "degree-level-other" } %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,9 @@ module ScholarsArchive
     config.autoload_paths << Rails.root.join('lib')
 
     config.rubycas.cas_base_url = ENV["SCHOLARSARCHIVE_CAS_BASE_URL"] || 'https://cas.myorganization.com'
+    config.to_prepare  do
+      Hyrax::CurationConcern.actor_factory = ScholarsArchive::DefaultMiddlewareStack.build_sa_stack
+    end
+
   end
 end

--- a/config/authorities/degree_field.yml
+++ b/config/authorities/degree_field.yml
@@ -968,3 +968,6 @@ terms:
 - id: "Zoology"	
   term: "Zoology"	
   active: true
+- id: "Other"
+  term: "Other"
+  active: true

--- a/db/migrate/20170714202009_create_other_options.rb
+++ b/db/migrate/20170714202009_create_other_options.rb
@@ -1,0 +1,13 @@
+class CreateOtherOptions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :other_options do |t|
+      t.string :work_id
+      t.string :name
+      t.string :property_name
+
+      t.timestamps
+    end
+    add_index :other_options, :work_id
+    add_index :other_options, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170606204140) do
+ActiveRecord::Schema.define(version: 20170714202009) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -166,6 +166,16 @@ ActiveRecord::Schema.define(version: 20170606204140) do
     t.datetime "created_at",                               null: false
     t.datetime "updated_at",                               null: false
     t.index ["namespace"], name: "index_minter_states_on_namespace", unique: true
+  end
+
+  create_table "other_options", force: :cascade do |t|
+    t.string   "work_id"
+    t.string   "name"
+    t.string   "property_name"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.index ["name"], name: "index_other_options_on_name"
+    t.index ["work_id"], name: "index_other_options_on_work_id"
   end
 
   create_table "permission_template_accesses", force: :cascade do |t|

--- a/spec/actors/scholars_archive/add_other_field_option_actor_spec.rb
+++ b/spec/actors/scholars_archive/add_other_field_option_actor_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+require 'spec_helper'
+RSpec.describe ScholarsArchive::Actors::AddOtherFieldOptionActor do
+  let(:curation_concern) do
+      GraduateThesisOrDissertation.new do |work|
+        work.attributes = attributes
+        work.save!
+      end
+  end
+  let(:ability) { double }
+  let(:user) do
+    User.new(email: 'test@example.com',guest: false) { |u| u.save!(validate: false)}
+  end
+  let(:env) { Hyrax::Actors::Environment.new(curation_concern, ability, attributes) }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:other_options) { OtherOption.all.to_a }
+
+  subject(:middleware) do
+    stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+      middleware.use described_class
+    end
+    stack.build(terminator)
+  end
+
+  describe '#create' do
+    context 'with other values selected for degree_field and degree_level' do
+      let(:attributes) { { title: ["test"], creator: ["Blah"], rights_statement: ["blah.blah"], resource_type: ["blah"], degree_field: "Other", degree_level: "Other" } }
+
+      before do
+        allow(terminator).to receive(:create).with(Hyrax::Actors::Environment).and_return(true)
+        curation_concern.apply_depositor_metadata(user.user_key)
+        curation_concern.degree_field_other = "test degree field other"
+        curation_concern.degree_level_other = "test degree level other"
+        curation_concern.save!
+      end
+      it "persists other values if they don't exist" do
+        expect(subject.create(env)).to be true
+        degree_field_other = OtherOption.find_by(name: "test degree field other", property_name: "degree_field", work_id: curation_concern.id)
+        degree_level_other = OtherOption.find_by(name: "test degree level other", property_name: "degree_level", work_id: curation_concern.id)
+        expect(other_options).to include(degree_field_other)
+        expect(other_options).to include(degree_level_other)
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'with other values selected for degree_field and degree_level' do
+      let(:attributes) { { title: ["test"], creator: ["Blah"], rights_statement: ["blah.blah"], resource_type: ["blah"], degree_field: "Other", degree_level: "Other" } }
+      before do
+        allow(terminator).to receive(:update).with(Hyrax::Actors::Environment).and_return(true)
+        curation_concern.apply_depositor_metadata(user.user_key)
+        curation_concern.degree_field_other = "test degree field other"
+        curation_concern.degree_level_other = "test degree level other"
+        curation_concern.save!
+      end
+      it "persists other values if they don't exist" do
+        expect(subject.update(env)).to be true
+        degree_field_other = OtherOption.find_by(name: "test degree field other", property_name: "degree_field", work_id: curation_concern.id)
+        degree_level_other = OtherOption.find_by(name: "test degree level other", property_name: "degree_level", work_id: curation_concern.id)
+        expect(other_options).to include(degree_field_other)
+        expect(other_options).to include(degree_level_other)
+      end
+    end
+  end
+end

--- a/spec/models/other_option_spec.rb
+++ b/spec/models/other_option_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe OtherOption, type: :model do
+  it "is valid with valid attributes" do
+    expect(OtherOption.new(name: "test", work_id: "test123abc", property_name: "degree_name")).to be_valid
+  end
+  it "is not valid without a proper attributes" do
+    other = OtherOption.new(name: nil, work_id: nil, property_name: nil)
+    expect(other).to_not be_valid
+  end
+end

--- a/spec/views/records/edit_fields/_degree_field.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_degree_field.html.erb_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'rails_helper'
+RSpec.describe 'records/edit_fields/_degree_field.html.erb', type: :view do
+  let(:ability) { double }
+  let(:work) {
+    GraduateThesisOrDissertation.new do |work|
+      work.attributes = attributes
+      work.save!
+    end
+  }
+  let(:form) do
+    Hyrax::GraduateThesisOrDissertationForm.new(work, ability, controller)
+  end
+  let(:form_template) do
+    %(
+      <%= simple_form_for [main_app, @form] do |f| %>
+        <%= render "records/edit_fields/degree_field", f: f, key: 'degree_field' %>
+      <% end %>
+    )
+  end
+
+  context "for a work with degree field where 'Other' was selected and there is an OtherOption record in the database" do
+    let(:attributes) { { title: ["test"], creator: ["Blah"], rights_statement: ["blah.blah"], resource_type: ["blah"], degree_field: "Other" } }
+    let(:degree_field_other_option_test) {"testing degree field other option"}
+
+    before do
+      OtherOption.find_or_create_by(name: degree_field_other_option_test, work_id: work.id)
+      work.degree_field_other = degree_field_other_option_test
+      assign(:form, form)
+      render inline: form_template
+    end
+
+    it 'has the "other" input visible in the form' do
+      expect(rendered).to have_selector('.degree-field-other input[type="text"]')
+    end
+
+    it 'has the "other" input value as the default in the form' do
+      expect(rendered).to have_selector('.degree-field-other input[value="'+degree_field_other_option_test+'"]')
+    end
+  end
+
+  context "for a work with degree field where 'Other' was not selected" do
+    let(:attributes) { { title: ["test"], creator: ["Blah"], rights_statement: ["blah.blah"], resource_type: ["blah"], degree_field: "test" } }
+
+    before do
+      assign(:form, form)
+      render inline: form_template
+    end
+
+    it 'has the "other" input hidden in the form' do
+      expect(rendered).to have_selector('.degree-field-other input[type="hidden"]', visible: false)
+      expect(rendered).to have_selector('.degree-field-other input.hidden', visible: false)
+    end
+  end
+end

--- a/spec/views/records/edit_fields/_degree_level.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_degree_level.html.erb_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'rails_helper'
+RSpec.describe 'records/edit_fields/_degree_level.html.erb', type: :view do
+  let(:ability) { double }
+  let(:work) {
+    GraduateThesisOrDissertation.new do |work|
+      work.attributes = attributes
+      work.save!
+    end
+  }
+  let(:form) do
+    Hyrax::GraduateThesisOrDissertationForm.new(work, ability, controller)
+  end
+  let(:form_template) do
+    %(
+      <%= simple_form_for [main_app, @form] do |f| %>
+        <%= render "records/edit_fields/degree_level", f: f, key: 'degree_level' %>
+      <% end %>
+    )
+  end
+
+  context "for a work with degree level where 'Other' was selected and there is an OtherOption record for that work" do
+    let(:attributes) { { title: ["test"], creator: ["Blah"], rights_statement: ["blah.blah"], resource_type: ["blah"], degree_level: "Other" } }
+    let(:degree_level_other_option_test) {"testing degree field other option"}
+
+    before do
+      OtherOption.find_or_create_by(name: degree_level_other_option_test, work_id: work.id)
+      work.degree_level_other = degree_level_other_option_test
+      assign(:form, form)
+      render inline: form_template
+    end
+
+    it 'has the "other" input visible in the form' do
+      expect(rendered).to have_selector('.degree-level-other input[type="text"]')
+    end
+
+    it 'has the "other" input value as the default in the form' do
+      expect(rendered).to have_selector('.degree-level-other input[value="'+degree_level_other_option_test+'"]')
+    end
+  end
+
+  context "for a work with degree level where 'Other' was not selected" do
+    let(:attributes) { { title: ["test"], creator: ["Blah"], rights_statement: ["blah.blah"], resource_type: ["blah"], degree_level: "test" } }
+
+    before do
+      assign(:form, form)
+      render inline: form_template
+    end
+
+    it 'has the "other" input hidden in the form' do
+      expect(rendered).to have_selector('.degree-level-other input[type="hidden"]', visible: false)
+      expect(rendered).to have_selector('.degree-level-other input.hidden', visible: false)
+    end
+  end
+end


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/3486120/28233832-976696ac-68ae-11e7-9b95-b23f6b99e813.png)

- Added add_other js and updated the form partials to allow the user to enter custom values when selecting "Other" for "degree_field" and "degree_level": fixes #719

- Implemented the `ScholarsArchive::Actors::AddOtherFieldOptionActor` that is used to persist "other" values provided by the user in the form into the `OtherOption` table: closes #727