### PR TITLE
set proper recipients in workflow configs and email notification objects

### DIFF
--- a/app/services/scholars_archive/workflow/changes_required_notification.rb
+++ b/app/services/scholars_archive/workflow/changes_required_notification.rb
@@ -13,7 +13,7 @@ module ScholarsArchive
 
       def users_to_notify
         user_key = document.depositor
-        super << ::User.find_by(email: user_key)
+        [::User.find_by(username: user_key)]
       end
     end
   end

--- a/app/services/scholars_archive/workflow/deposit_received_notification.rb
+++ b/app/services/scholars_archive/workflow/deposit_received_notification.rb
@@ -11,8 +11,9 @@ module ScholarsArchive
         "ScholarsArchive@OSU has received your deposit: #{title} (#{link_to work_id, document_path}). Your item is under review by repository administrators. You will be notified if your deposit requires additional changes and/or when your deposit is live in the repository. \n\n #{comment}"
       end
 
+      # Add the user who initiated this action to the list of users being notified
       def users_to_notify
-        super << user
+        [user]
       end
     end
   end

--- a/app/services/scholars_archive/workflow/deposited_notification.rb
+++ b/app/services/scholars_archive/workflow/deposited_notification.rb
@@ -13,7 +13,7 @@ module ScholarsArchive
 
       def users_to_notify
         user_key = ActiveFedora::Base.find(work_id).depositor
-        super << ::User.find_by(email: user_key)
+        [::User.find_by(username: user_key)]
       end
     end
   end

--- a/app/services/scholars_archive/workflow/pending_review_notification.rb
+++ b/app/services/scholars_archive/workflow/pending_review_notification.rb
@@ -12,7 +12,7 @@ module ScholarsArchive
       end
 
       def users_to_notify
-        super << user
+        super
       end
     end
   end

--- a/config/workflows/datasets.json
+++ b/config/workflows/datasets.json
@@ -46,7 +46,7 @@
             "notifications": [{
                 "notification_type": "email",
                 "name": "ScholarsArchive::Workflow::DepositedNotification",
-                "to": ["approving"]
+                "to": ["depositing"]
             }],
             "methods": [
                 "Hyrax::Workflow::RevokeEditFromDepositor",

--- a/config/workflows/gtd.json
+++ b/config/workflows/gtd.json
@@ -46,7 +46,7 @@
             "notifications": [{
                 "notification_type": "email",
                 "name": "ScholarsArchive::Workflow::DepositedNotification",
-                "to": ["approving"]
+                "to": ["depositing"]
             }],
             "methods": [
                 "Hyrax::Workflow::RevokeEditFromDepositor",
@@ -62,7 +62,7 @@
             "notifications": [{
                 "notification_type": "email",
                 "name": "ScholarsArchive::Workflow::DepositedNotification",
-                "to": ["approving"]
+                "to": ["depositing"]
             }],
             "methods": [
                 "Hyrax::Workflow::RevokeEditFromDepositor",

--- a/config/workflows/one_step.json
+++ b/config/workflows/one_step.json
@@ -46,7 +46,7 @@
             "notifications": [{
                 "notification_type": "email",
                 "name": "ScholarsArchive::Workflow::DepositedNotification",
-                "to": ["approving"]
+                "to": ["depositing"]
             }],
             "methods": [
                 "Hyrax::Workflow::RevokeEditFromDepositor",

--- a/config/workflows/stakeholder.json
+++ b/config/workflows/stakeholder.json
@@ -46,7 +46,7 @@
             "notifications": [{
                 "notification_type": "email",
                 "name": "ScholarsArchive::Workflow::DepositedNotification",
-                "to": ["approving"]
+                "to": ["depositing"]
             }],
             "methods": [
                 "Hyrax::Workflow::RevokeEditFromDepositor",


### PR DESCRIPTION
- Updated `ChangesRequiredNotification` and `DepositReceivedNotification` to send to the user who initiated deposit only
- Updated `PendingReviewNotification` to send the emails to the approving role only (the user who made the deposit should get the `DepositReceivedNotification` email instead)
- Added diagrams for One Step and Graduate Thesis and Dissertation Workflows: https://github.com/osulp/Scholars-Archive/wiki/Workflows