### PR TITLE
updated select inputs to display all options for admin users

### DIFF
--- a/app/services/scholars_archive/academic_units_service.rb
+++ b/app/services/scholars_archive/academic_units_service.rb
@@ -13,6 +13,10 @@ module ScholarsArchive
       select_active_options.sort
     end
 
+    def select_sorted_all_options
+      select_all_options.sort
+    end
+
     def select_sorted_current_options
       select_sorted_active_options.select { |active_option| EdtfDateCompareService.includes_last_five_years?(active_option) }
     end

--- a/app/services/scholars_archive/degree_field_service.rb
+++ b/app/services/scholars_archive/degree_field_service.rb
@@ -13,6 +13,10 @@ module ScholarsArchive
       select_active_options.sort
     end
 
+    def select_sorted_all_options
+      select_all_options.sort
+    end
+
     def select_sorted_current_options
       select_sorted_active_options.select { |active_option| EdtfDateCompareService.includes_last_five_years?(active_option) }
     end

--- a/app/services/scholars_archive/degree_level_service.rb
+++ b/app/services/scholars_archive/degree_level_service.rb
@@ -4,5 +4,9 @@ module ScholarsArchive
     def initialize
       super('degree_level')
     end
+
+    def select_sorted_all_options
+      select_all_options.sort
+    end
   end
 end

--- a/app/services/scholars_archive/language_service.rb
+++ b/app/services/scholars_archive/language_service.rb
@@ -8,5 +8,9 @@ module ScholarsArchive
     def all_labels(values)
       @authority.all.select { |r| values.include?(r[:id]) }.map { |hash| hash['label'] }
     end
+
+    def select_sorted_all_options
+      select_all_options.sort
+    end
   end
 end

--- a/app/services/scholars_archive/license_service.rb
+++ b/app/services/scholars_archive/license_service.rb
@@ -24,5 +24,9 @@ module ScholarsArchive
       end
       [render_options, html_options]
     end
+
+    def select_sorted_all_options
+      select_all_options.sort
+    end
   end
 end

--- a/app/services/scholars_archive/peerreviewed_service.rb
+++ b/app/services/scholars_archive/peerreviewed_service.rb
@@ -8,5 +8,9 @@ module ScholarsArchive
       values ||= []
       @authority.all.select { |r| values.include?(r[:id]) }.map { |hash| hash['label'] }
     end
+
+    def select_sorted_all_options
+      select_all_options.sort
+    end
   end
 end

--- a/app/views/records/edit_fields/_academic_affiliation.html.erb
+++ b/app/views/records/edit_fields/_academic_affiliation.html.erb
@@ -1,5 +1,5 @@
 <% academic_units_service = ScholarsArchive::AcademicUnitsService.new %>
 <%= f.input :academic_affiliation, as: :multi_value_select,
-  collection: academic_units_service.select_sorted_current_options,
+  collection: current_user.admin? ? academic_units_service.select_sorted_all_options : academic_units_service.select_sorted_current_options,
   include_blank: true,
   input_html: { class: "form-control language-default-select #{f.object.new_record? ? 'new-record' : ''}" } %>

--- a/app/views/records/edit_fields/_degree_field.html.erb
+++ b/app/views/records/edit_fields/_degree_field.html.erb
@@ -1,6 +1,6 @@
 <% degree_field_service = ScholarsArchive::DegreeFieldService.new %>
 <%= f.input :degree_field,
-    collection: degree_field_service.select_sorted_current_options,
+    collection: current_user.admin? ? degree_field_service.select_sorted_all_options : degree_field_service.select_sorted_current_options,
     include_blank: true,
     input_html: { class: "form-control degree-field-selector"} %>
 <% if f.object.model.degree_field.present? && f.object.model.degree_field == 'Other' && f.object.model.degree_field_other.present? %>

--- a/app/views/records/edit_fields/_degree_level.html.erb
+++ b/app/views/records/edit_fields/_degree_level.html.erb
@@ -1,6 +1,6 @@
 <% degree_level_service = ScholarsArchive::DegreeLevelService.new %>
 <%= f.input :degree_level,
-    collection: degree_level_service.select_active_options,
+    collection: current_user.admin? ? degree_level_service.select_sorted_all_options : degree_level_service.select_active_options,
     include_blank: true,
     input_html: { class: "form-control degree-level-selector" } %>
 <% if f.object.model.degree_level.present? && f.object.model.degree_level == 'Other' && f.object.model.degree_level_other.present? %>

--- a/app/views/records/edit_fields/_language.html.erb
+++ b/app/views/records/edit_fields/_language.html.erb
@@ -1,5 +1,5 @@
 <% language_service = ScholarsArchive::LanguageService.new %>
 <%= f.input :language, as: :multi_value_select,
-  collection: language_service.select_active_options,
+  collection: current_user.admin? ? language_service.select_sorted_all_options : language_service.select_active_options,
   include_blank: true,
   input_html: { class: "form-control language-default-select #{f.object.new_record? ? 'new-record' : ''}" } %>

--- a/app/views/records/edit_fields/_license.html.erb
+++ b/app/views/records/edit_fields/_license.html.erb
@@ -1,6 +1,6 @@
 <% license_service = ScholarsArchive::LicenseService.new %>
 <%= f.input :license, as: :select,
-    collection: license_service.select_active_options_from_model(f),
+    collection: current_user.admin? ? license_service.select_sorted_all_options : license_service.select_active_options_from_model(f),
     include_blank: true,
     item_helper: license_service.method(:include_current_value),
     input_html: { class: 'form-control' } %>

--- a/app/views/records/edit_fields/_peerreviewed.html.erb
+++ b/app/views/records/edit_fields/_peerreviewed.html.erb
@@ -1,5 +1,5 @@
 <% service = ScholarsArchive::PeerreviewedService.new %>
 <%= f.input :peerreviewed,
-    collection: service.select_active_options,
+    collection: current_user.admin? ? service.select_sorted_all_options : service.select_active_options,
     include_blank: true,
     input_html: { class: "form-control" } %>

--- a/spec/views/records/edit_fields/_degree_level.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_degree_level.html.erb_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 require 'rails_helper'
 RSpec.describe 'records/edit_fields/_degree_level.html.erb', type: :view do
-  let(:ability) { double }
+  let(:ability) { double(current_user: current_user) }
+  let(:current_user) { User.new(email: 'test@example.com',guest: false) }
+
   let(:work) {
     GraduateThesisOrDissertation.new do |work|
       work.attributes = attributes
@@ -17,6 +19,12 @@ RSpec.describe 'records/edit_fields/_degree_level.html.erb', type: :view do
         <%= render "records/edit_fields/degree_level", f: f, key: 'degree_level' %>
       <% end %>
     )
+  end
+
+  before do
+    allow(view).to receive(:signed_in?).and_return(true)
+    allow(view).to receive(:current_user).and_return(current_user)
+    allow(view).to receive(:can?).and_return(true)
   end
 
   context "for a work with degree level where 'Other' was selected and there is an OtherOption record for that work" do


### PR DESCRIPTION
Updated dropdown options in the following fields to display all options available (active and inactive for admin users)

- academic_affiliation
- degree_field
- degree_level
- language
- license
- peerreviewed

fixes #733 