### PR TITLE
added facet partial for date_decades to render custom desc sorting

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -67,7 +67,7 @@ class CatalogController < ApplicationController
     #config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type", limit: 5
     #config.add_facet_field solr_name('member_of_collections', :symbol), limit: 5, label: 'Collections'
 
-    config.add_facet_field 'date_decades_ssim', :label => 'Decade', :limit => 10, sort: 'index'
+    config.add_facet_field 'date_decades_ssim', :label => 'Decade', :limit => 10, sort: 'index', partial: 'date_decades_facet'
     config.add_facet_field 'date_facet_yearly_ssim', :label => 'Date', :range => true
 
     # The generic_type isn't displayed on the facet list

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -87,4 +87,9 @@ module ApplicationHelper
     search_path = Rails.application.class.routes.url_helpers.search_catalog_path(:f => {field => [query]})
     link_to(query, search_path)
   end
+
+  def facet_desc_sort!(items=[])
+    items.sort! { |a,b| b.value.downcase <=> a.value.downcase }
+    items
+  end
 end

--- a/app/views/catalog/_date_decades_facet.html.erb
+++ b/app/views/catalog/_date_decades_facet.html.erb
@@ -1,0 +1,13 @@
+<ul class="facet-values list-unstyled">
+  <% facet_desc_sort!(display_facet.items.to_a) if params[:action] == "index" || params['facet.sort'].blank?  %>
+  <% paginator = facet_paginator(facet_field, display_facet) %>
+  <%= render_facet_limit_list paginator, facet_field.key %>
+
+  <% unless paginator.last_page? || params[:action] == "facet" %>
+      <li class="more_facets_link">
+        <%= link_to t("more_#{field_name}_html", scope: 'blacklight.search.facets', default: :more_html, field_name: facet_field.label),
+                    search_facet_path(id: facet_field.key),
+                    data: { blacklight_modal: 'trigger' }, class: 'more_facets_link' %>
+      </li>
+  <% end %>
+</ul>


### PR DESCRIPTION
Blacklight currently supports only two types of sorting in a facet_field: `index` (ascending alpha)  and `count` (hits per item), see https://github.com/projectblacklight/blacklight/wiki/Configuration---Facet-Fields

However, it allows us to render a partial for a facet_field where we have access to `display_facet.items` that holds all the facet results that can be sorted as needed before the pagination is set. With this approach, added the partial `app/views/catalog/date_decades_facet`, which uses the `facet_desc_sort!` helper to apply the custom sorting. 

![image](https://user-images.githubusercontent.com/3486120/29342105-b8c4ef90-81dd-11e7-8c8c-1e461ddb9b82.png)

fixes #701 