### PR TITLE
Default query and filter in view

### DIFF
--- a/app/views/hyrax/admin/workflows/index.html.erb
+++ b/app/views/hyrax/admin/workflows/index.html.erb
@@ -1,0 +1,102 @@
+<% provide :page_header do %>
+  <h1><span class="glyphicon glyphicon-ok-circle"></span> <%= t('.header') %></h1>
+<% end %>
+
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default tabs">
+      <ul class="nav nav-tabs" role="tablist">
+        <li class="active">
+          <a href="#under-review" role="tab" data-toggle="tab"><%= t('.tabs.under_review') %></a>
+        </li>
+        <li>
+          <a href="#published" role="tab" data-toggle="tab"><%= t('.tabs.published') %></a>
+        </li>
+      </ul>
+      <div class="tab-content">
+        <div id="under-review" class="tab-pane active">
+          <div class="panel panel-default labels">
+            <div class="panel-body">
+              <div class="table-responsive">
+                <table class="table table-condensed table-striped datatable">
+                  <thead>
+                    <tr>
+                      <th width="40%">Work</th>
+                      <th width="20%">Depositor</th>
+                      <th width="20%">Submission Date</th>
+                      <th width="20%">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% @status_list.each do |document| %>
+                      <!-- Filtering for deposited or not deposited happens here. The hyrax ticket that will solve this is
+                        ticket number 1395 in hyrax. 1395#Solr Error when visiting Review Submissions tab-->
+
+                      <% unless document.workflow_state == "Deposited" %>
+                        <tr>
+                          <td>
+                            <%= link_to document, [main_app, document] %>
+                          </td>
+                          <td>
+                            <%= document.depositor %>
+                          </td>
+                          <td>
+                            <%= document.date_modified %>
+                          </td>
+                          <td>
+                            <span class="state state-pending"><%= document.workflow_state %></span>
+                          </td>
+                        </tr>
+                      <% end %>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="published" class="tab-pane">
+          <div class="panel panel-default labels">
+            <div class="panel-body">
+              <div class="table-responsive">
+                <table class="table table-condensed table-striped datatable">
+                  <thead>
+                    <tr>
+                      <th width="40%">Work</th>
+                      <th width="20%">Depositor</th>
+                      <th width="20%">Submission Date</th>
+                      <th width="20%">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% @published_list.each do |document| %>
+                      <!-- Filtering for deposited or not deposited happens here. The hyrax ticket that will solve this is
+                        ticket number 1395 in hyrax. 1395#Solr Error when visiting Review Submissions tab-->
+                      <% if document.workflow_state == "Deposited" %>
+                        <tr>
+                          <td>
+                            <%= link_to document, [main_app, document] %>
+                          </td>
+                          <td>
+                            <%= safe_join(document.creator, tag(:br)) %>
+                          </td>
+                          <td>
+                            <%= document.date_modified %>
+                          </td>
+                          <td>
+                            <span class="state state-pending"><%= document.workflow_state %></span>
+                          </td>
+                        </tr>
+                      <% end %>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/initializers/hyrax_status_list_service_hack.rb
+++ b/config/initializers/hyrax_status_list_service_hack.rb
@@ -1,0 +1,8 @@
+Hyrax::Workflow::StatusListService.class_eval do 
+  def search_solr
+    actionable_roles = roles_for_user
+    logger.debug("Actionable roles for #{user.user_key} are #{actionable_roles}")
+    return [] if actionable_roles.empty?
+    Hyrax::WorkRelation.new.search_with_conditions(query(actionable_roles), {df: 'actionable_workflow_roles', defType: 'edismax', rows: 1000})
+  end
+end


### PR DESCRIPTION
With just greg's fix, the lists weren't filtering. So I had to figure out some way to filter the lists out. This allows the lists to be filtered but in the view. The other place to filter this would be here. https://github.com/samvera/hyrax/blob/master/app/controllers/hyrax/admin/workflows_controller.rb#L17

However, @status_list is a status_list_service that has select as a private method. It makes it slightly difficult to filter out the proper objects. The only other way I could see it filtered is using the proper solr_query but that seems like a low level issue that we chose to not look into right now. For now, I propose just filtering in the view and calling it a day. Ill make a ticket that describes the issue and make comments where necessary.