### PR TITLE
update GTD workflow so that items don't get stuck

### DIFF
--- a/config/workflows/gtd.json
+++ b/config/workflows/gtd.json
@@ -69,12 +69,12 @@
                 "Hyrax::Workflow::ActivateObject"
             ]
         }, {
-            "name": "Request Review",
+            "name": "Restart Review Process",
             "from_states": [{
                 "names": ["Changes Required"],
                 "roles": ["depositing"]
             }],
-            "transition_to": "Pending Review",
+            "transition_to": "Graduate School Review",
             "notifications": [{
                 "notification_type": "email",
                 "name": "ScholarsArchive::Workflow::PendingReviewNotification",


### PR DESCRIPTION
items were getting stuck in Pending Review state. Removed Request Review action and replaced it with Restart Review Process action that takes item back to Graduate School Review state