### PR TITLE
Feature/set feature researcher as default tab

### DIFF
--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -21,11 +21,11 @@
   </ul>
 
   <div class="tab-content">
-    <div class="tab-pane" id="tab-col2-first">
+    <div class="tab-pane active" id="tab-col2-first">
       <h2 class="sr-only"><%= t('hyrax.homepage.featured_researcher.title') %></h2>
       <%= render 'featured_researcher' %>
     </div>
-    <div class="tab-pane active" id="tab-col2-second">
+    <div class="tab-pane" id="tab-col2-second">
       <h2 class="sr-only"><%= t('hyrax.homepage.admin_sets.title') %></h2>
       <%= render 'explore_collections', collections: @presenter.collections %>
     </div>

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -1,0 +1,33 @@
+<div class="col-xs-12 col-sm-6">
+  <ul id="homeTabs" class="nav nav-tabs">
+    <li class="active"><a href="#featured_container" data-toggle="tab" role="tab" id="featureTab"><%= t('hyrax.homepage.featured_works.tab_label') %></a></li>
+    <li><a href="#recently_uploaded" data-toggle="tab" role="tab" id="recentTab"><%= t('hyrax.homepage.recently_uploaded.tab_label') %></a></li>
+  </ul>
+  <div class="tab-content">
+    <div class="tab-pane fade in active" id="featured_container" role="tabpanel" aria-labelledby="featureTab">
+      <%= render 'featured_works' %>
+    </div>
+    <div class="tab-pane fade" id="recently_uploaded" role="tabpanel" aria-labelledby="recentTab">
+      <%= render 'recently_uploaded', recent_documents: @recent_documents %>
+    </div>
+  </div>
+</div><!-- /.col-xs-6 -->
+
+<div class="col-xs-12 col-sm-6">
+
+  <ul class="nav nav-tabs" role="tablist">
+    <li class="active"><a aria-expanded="true" href="#tab-col2-first" role="tab" data-toggle="tab"><%= t('hyrax.homepage.featured_researcher.tab_label') %></a></li>
+    <li class=""><a aria-expanded="false" href="#tab-col2-second" role="tab" data-toggle="tab"><%= t('hyrax.homepage.admin_sets.title') %></a></li>
+  </ul>
+
+  <div class="tab-content">
+    <div class="tab-pane" id="tab-col2-first">
+      <h2 class="sr-only"><%= t('hyrax.homepage.featured_researcher.title') %></h2>
+      <%= render 'featured_researcher' %>
+    </div>
+    <div class="tab-pane active" id="tab-col2-second">
+      <h2 class="sr-only"><%= t('hyrax.homepage.admin_sets.title') %></h2>
+      <%= render 'explore_collections', collections: @presenter.collections %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
fixes #904 

- updated each `tab-pane` under `ul` with role `tablist` in hyrax/homepage/_home_content.html.erb partial so that `featured_researcher` is rendered under `tab-col2-first` and `explore_collections` under `tab-col2-second`.

![image](https://user-images.githubusercontent.com/3486120/30606845-e89a993a-9d27-11e7-98ae-5d0e7a176952.png)
