### PR TITLE
add monit restart after deploy:published hook

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -60,3 +60,12 @@ set :branch, config['branch']
 #     auth_methods: %w(publickey password)
 #     # password: 'please use keys'
 #   }
+
+namespace :deploy do
+  # tell monit to restart all defined processes (i.e. puma, sidekiq)
+  after 'deploy:published', :restart_monit do
+    on roles(:app) do
+      execute "sudo /usr/bin/monit restart all"
+    end
+  end
+end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -65,7 +65,7 @@ namespace :deploy do
   # tell monit to restart all defined processes (i.e. puma, sidekiq)
   after 'deploy:published', :restart_monit do
     on roles(:app) do
-      execute "sudo /usr/bin/monit restart all"
+      run "sudo /usr/bin/monit restart all"
     end
   end
 end

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -60,3 +60,12 @@ set :branch, config['branch']
 #     auth_methods: %w(publickey password)
 #     # password: 'please use keys'
 #   }
+
+namespace :deploy do
+  # tell monit to restart all defined processes (i.e. puma, sidekiq)
+  after 'deploy:published', :restart_monit do
+    on roles(:app) do
+      execute "sudo /usr/bin/monit restart all"
+    end
+  end
+end

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -65,7 +65,7 @@ namespace :deploy do
   # tell monit to restart all defined processes (i.e. puma, sidekiq)
   after 'deploy:published', :restart_monit do
     on roles(:app) do
-      execute "sudo /usr/bin/monit restart all"
+      run "sudo /usr/bin/monit restart all"
     end
   end
 end


### PR DESCRIPTION
It looks like we can restart processes with `sudo /usr/bin/monit restart all`. This would allow us to restart existing puma and sidekiq processes on deploy, ref #914 