### PR TITLE
updated featured fields to use subject instead of keyword

### DIFF
--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -1,0 +1,16 @@
+<h3>
+  <span class="sr-only">Title</span>
+  <%= link_to truncate(featured.title.first, length: 28, separator: ' '), [main_app, featured] %>
+</h3>
+<div>
+  <span class="sr-only">Depositor</span>
+  <%= link_to_profile featured.depositor("no depositor value") %>
+</div>
+<div>
+  <span class="sr-only">File type</span>
+  <%= link_to_facet_list(featured.resource_type, 'resource_type', 'no resource specified') %>
+</div>
+<div>
+  <span class="sr-only">Keywords</span>
+  <%= link_to_facet_list(featured.subject, 'keyword', '') %>
+</div>


### PR DESCRIPTION
updated keywords row on featured pane to use `featured.subject` instead of `featured.keyword` and set empty string for no results

fixes #909 