### PR TITLE
return nil after sending error message to logs

### DIFF
--- a/app/services/scholars_archive/triple_powered_service.rb
+++ b/app/services/scholars_archive/triple_powered_service.rb
@@ -93,6 +93,7 @@ module ScholarsArchive
           @triplestore.fetch(uri, from_remote: true)
         rescue TriplestoreAdapter::TriplestoreException => e
           Rails.logger.warn e.message
+          return nil
         end
       end
     end


### PR DESCRIPTION
fixes #938 

It turns out that we were sending the error to the logs, but we were not returning `nil`, which is the expected behavior when retrieving labels and the graph is not available (see https://github.com/osulp/Scholars-Archive/blob/master/app/services/scholars_archive/triple_powered_service.rb#L65)

I found that sending the error to rails logger returned `true` by default, which ended up causing the query to fail on `ScholarsArchive::TriplePoweredService.predicate_labels(graph)` (see https://github.com/osulp/Scholars-Archive/blob/master/app/services/scholars_archive/triple_powered_service.rb#L70)
