### PR TITLE
Feature/update deploy hook

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -39,3 +39,11 @@ append :linked_dirs, 'log', 'tmp', 'config/puma', 'public/assets'
 set :keep_releases, 5
 
 set :passenger_restart_with_touch, true
+
+# tell monit to restart all defined processes (i.e. puma, sidekiq)
+task :restart_monit do
+  on roles(:app) do
+    execute "sudo /usr/bin/monit restart all"
+  end
+end
+after "deploy:published", "restart_monit"

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -61,11 +61,4 @@ set :branch, config['branch']
 #     # password: 'please use keys'
 #   }
 
-namespace :deploy do
-  # tell monit to restart all defined processes (i.e. puma, sidekiq)
-  after 'deploy:published', :restart_monit do
-    on roles(:app) do
-      run "sudo /usr/bin/monit restart all"
-    end
-  end
-end
+

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -61,11 +61,4 @@ set :branch, config['branch']
 #     # password: 'please use keys'
 #   }
 
-namespace :deploy do
-  # tell monit to restart all defined processes (i.e. puma, sidekiq)
-  after 'deploy:published', :restart_monit do
-    on roles(:app) do
-      run "sudo /usr/bin/monit restart all"
-    end
-  end
-end
+


### PR DESCRIPTION
this update fixes the `ArgumentError` in our `deploy:published` hook that failed during our last deploy:

```
ArgumentError: wrong number of arguments (given 1, expected 0)

Tasks: TOP => deploy:restart_monit
(See full trace by running task with --trace)
...
** DEPLOY FAILED
** Refer to log/capistrano.log for details. Here are the last 20 lines:
```