### PR TITLE
Create head_tag_extras partial to load Open Sans font.

### DIFF
--- a/app/views/_head_tag_extras.html.erb
+++ b/app/views/_head_tag_extras.html.erb
@@ -1,0 +1,1 @@
+<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600" rel="stylesheet">


### PR DESCRIPTION
Fixes #944 