### PR TITLE
Feature/fedora timeout patch

### DIFF
--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -13,6 +13,7 @@ production:
   password: fedoraAdmin
   url: <%= ENV['SCHOLARSARCHIVE_FEDORA_URL'] %>
   base_path: /prod
+  request: { timeout: 600, open_timeout: 60}
 staging:
   user: fedoraAdmin
   password: fedoraAdmin

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -13,7 +13,7 @@ production:
   password: fedoraAdmin
   url: <%= ENV['SCHOLARSARCHIVE_FEDORA_URL'] %>
   base_path: /prod
-  request: { timeout: 600, open_timeout: 60}
+  request: { timeout: 1000, open_timeout: 100}
 staging:
   user: fedoraAdmin
   password: fedoraAdmin

--- a/config/initializers/active_fedora_timeout_monkey_patch.rb
+++ b/config/initializers/active_fedora_timeout_monkey_patch.rb
@@ -1,9 +1,11 @@
 class ActiveFedora::Fedora
+  def request_options
+    @config[:request]
+  end
+
   def authorized_connection
     options = {}
-    if @config[:timeout]
-      options[:request] = { timeout: @config[:timeout].to_i }
-    end
+    options[:request] = request_options if request_options
     connection = Faraday.new(host, options)
     connection.basic_auth(user, password)
     connection

--- a/config/initializers/active_fedora_timeout_monkey_patch.rb
+++ b/config/initializers/active_fedora_timeout_monkey_patch.rb
@@ -1,0 +1,11 @@
+class ActiveFedora::Fedora
+  def authorized_connection
+    options = {}
+    if @config[:timeout]
+      options[:request] = { timeout: @config[:timeout].to_i }
+    end
+    connection = Faraday.new(host, options)
+    connection.basic_auth(user, password)
+    connection
+  end
+end


### PR DESCRIPTION
The error `Faraday::TimeoutError: Net::ReadTimeout` described in https://github.com/osulp/Scholars-Archive/issues/867 seems to be occurring when active-fedora takes a longer to start than the default timeout that Faraday is allowed to wait.

Allowing an extended/custom timeout in `fedora.yml` has already been addressed in this PR https://github.com/samvera/active_fedora/pull/1271, but apparently, it hasn't been released yet. There is some discussion regarding this update in this ticket: https://github.com/samvera/active_fedora/issues/1105

`config/initializers/active_fedora_timeout_monkey_patch.rb` is a temporary patch for now until the update active_fedora PR#1271 gets released. 