### PR TITLE
enabled citations metatags (twitter_meta, gscholar_meta) in work show…

### DIFF
--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,4 +1,7 @@
 <% provide :page_title, @presenter.page_title %>
+
+<%= render 'shared/citations' %>
+
 <div itemscope itemtype="http://schema.org/CreativeWork" class="row">
   <div class="col-xs-12">
     <header>
@@ -12,7 +15,8 @@
   </div>
   <div class="col-sm-4">
     <%= render "show_actions", presenter: @presenter %>
-    <%= t('.last_modified', value: @presenter.date_modified) %>
+    <%# Use the fully qualified path to avoid RSpec error: translation missing: en.hyrax.base.show.html.erb.last_modified %>
+    <%= t('hyrax.base.show.last_modified', value: @presenter.date_modified) %>
     <%= render 'representative_media', presenter: @presenter %>
     <%= render 'social_media' %>
     <%= render 'citations', presenter: @presenter %>


### PR DESCRIPTION
…page

fixes #597 

pulled updates for `app/views/hyrax/base/show.html.erb` from hyrax that now includes the partial `shared/citations`, which includes the metadata available (`twitter_meta` and `gscholar_meta`, see https://github.com/samvera/hyrax/blob/master/app/views/shared/_citations.html.erb) in hyrax for the show page