### PR TITLE
updated resolrize_job and active_fedora_timeout_monkey_patch to allow…

### DIFF
--- a/app/jobs/resolrize_job.rb
+++ b/app/jobs/resolrize_job.rb
@@ -1,0 +1,9 @@
+class ResolrizeJob < Hyrax::ApplicationJob
+  # Note: Exposing arguments available in ActiveFedora::Base.reindex_everything: batch_size, softCommit, progress_bar and final_commit
+  def perform(batch_size: 50, softCommit: true, progress_bar: false, final_commit: false)
+    ActiveFedora::Base.reindex_everything(batch_size: batch_size,
+                                          softCommit: softCommit,
+                                          progress_bar: progress_bar,
+                                          final_commit: final_commit)
+  end
+end

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -3,21 +3,22 @@ development:
   password: fedoraAdmin
   url: http://127.0.0.1:<%= ENV['FCREPO_DEVELOPMENT_PORT'] || 8984 %>/rest
   base_path: /dev
-  request: { timeout: 1000, open_timeout: 100}
+  request: { timeout: 1000, open_timeout: 1000}
 test:
   user: fedoraAdmin
   password: fedoraAdmin
   url: http://127.0.0.1:<%= ENV['FCREPO_TEST_PORT'] || 8986 %>/rest
   base_path: /test
-  request: { timeout: 1000, open_timeout: 100}
+  request: { timeout: 1000, open_timeout: 1000}
 production:
   user: fedoraAdmin
   password: fedoraAdmin
   url: <%= ENV['SCHOLARSARCHIVE_FEDORA_URL'] %>
   base_path: /prod
-  request: { timeout: 1000, open_timeout: 100}
+  request: { timeout: 1000, open_timeout: 1000}
 staging:
   user: fedoraAdmin
   password: fedoraAdmin
   url: <%= ENV['SCHOLARSARCHIVE_FEDORA_URL'] %>
   base_path: /staging
+  request: { timeout: 1000, open_timeout: 1000}

--- a/config/initializers/active_fedora_timeout_monkey_patch.rb
+++ b/config/initializers/active_fedora_timeout_monkey_patch.rb
@@ -1,13 +1,16 @@
 # TODO: we can remove this file once this PR https://github.com/samvera/active_fedora/pull/1271 is released in active-fedora
 
 module ActiveFedoraOverride
+  def request_options
+    @config[:request]
+  end
+
   def authorized_connection
     super.tap do |conn|
-      if @config[:request][:timeout] && @config[:request][:timeout].to_i > 0
-        conn.options[:timeout] = @config[:request][:timeout].to_i
-      end
-      if @config[:request][:open_timeout] && @config[:request][:open_timeout].to_i > 0
-        conn.options[:open_timeout] = @config[:request][:open_timeout].to_i
+      if request_options
+        request_options.each do |option, value|
+          conn.options[option.to_sym] = value
+        end
       end
     end
   end


### PR DESCRIPTION
… more options

- Added custom resolrize_job to use arguments available for `ActiveFedora::Base.reindex_everything` (i.e batch_size) that can be useful to fine-tune the resolrize_job
- Refactored ` config/initializers/active_fedora_timeout_monkey_patch.rb` to grab all the 'request' options provided in `fedora.yml` 