### PR TITLE
fetch all labels for mult-value fields

### DIFF
--- a/app/indexers/default_work_indexer.rb
+++ b/app/indexers/default_work_indexer.rb
@@ -21,10 +21,11 @@ class DefaultWorkIndexer < Hyrax::WorkIndexer
       object.triple_powered_properties.each do |o|
         if ScholarsArchive::FormMetadataService.multiple? object.class, o[:field]
           uris = object.send(o[:field])
+          labels = ScholarsArchive::TriplePoweredService.new.fetch_all_labels(uris)
         else
           uris = Array(object.send(o[:field]))
+          labels = ScholarsArchive::TriplePoweredService.new.fetch_top_label(uris, parse_date: o[:has_date])
         end
-        labels = ScholarsArchive::TriplePoweredService.new.fetch_top_label(uris, parse_date: o[:has_date])
         solr_doc[o[:field].to_s + '_label_ssim'] = labels
         solr_doc[o[:field].to_s + '_label_tesim'] = labels
       end


### PR DESCRIPTION
fixes #973 

- It looks like we were fetching only the top label with `fetch_top_label` which works for single value fields. 
- Added `fetch_all_labels` (instead of `fetch_top_label`) to get an array of label entries instead for multi-value fields like`other_affiliation`

![image](https://user-images.githubusercontent.com/3486120/32304473-bc717f5a-bf2c-11e7-8eb7-8d4da0c355fe.png)
