### PR TITLE
Redirec handle to solrquery

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -157,7 +157,7 @@ class CatalogController < ApplicationController
       all_names = config.show_fields.values.map(&:field).join(" ")
       title_name = solr_name("title", :stored_searchable)
       field.solr_parameters = {
-        qf: "#{all_names} degree_grantors_label_tesim nested_related_items_label_tesim degree_field_label_tesim file_format_tesim all_text_timv language_label_tesim rights_statement_label_tesim license_label_tesim academic_affiliation_label_tesim other_affiliation_label_tesim",
+        qf: "#{all_names} dspace_community_tesim dspace_collection_tesim degree_grantors_label_tesim nested_related_items_label_tesim degree_field_label_tesim file_format_tesim all_text_timv language_label_tesim rights_statement_label_tesim license_label_tesim academic_affiliation_label_tesim other_affiliation_label_tesim",
         pf: title_name.to_s
       }
     end
@@ -199,6 +199,22 @@ class CatalogController < ApplicationController
 
     config.add_search_field('other_affiliation_label') do |field|
       solr_name = solr_name("other_affiliation_label", :stored_searchable)
+      field.solr_local_parameters = {
+        qf: solr_name,
+        pf: solr_name
+      }
+    end
+
+    config.add_search_field('dspace_collection') do |field|
+      solr_name = solr_name("dspace_collection", :stored_searchable)
+      field.solr_local_parameters = {
+        qf: solr_name,
+        pf: solr_name
+      }
+    end
+
+    config.add_search_field('dspace_community') do |field|
+      solr_name = solr_name("dspace_community", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name

--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -80,9 +80,11 @@ module ScholarsArchive
       end
 
       property :dspace_collection, predicate: ::RDF::URI.new("http://opaquenamespace.org/ns/dspaceCollection") do |index|
+        index.as :stored_searchable
       end
 
       property :dspace_community, predicate: ::RDF::URI.new("http://opaquenamespace.org/ns/dspaceCommunity") do |index|
+        index.as :stored_searchable
       end
 
       property :embargo_reason, predicate: ::RDF::Vocab::DC.accessRights, multiple: false do |index|


### PR DESCRIPTION
this update exposes `dspace_collection` and `dspace_community` as search fields so that we can search the catalog as follows:
```
localhost:3000/catalog?q=hello+world&search_field=dspace_collection
```
references #1015 