### PR TITLE
added fix to generate citation pdf urls for child filesets

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,11 @@ class ApplicationController < ActionController::Base
   end
 
   def default_url_options(options={})
-    options.merge(protocol: :https)
+    if Rails.env == "production"
+      options.merge(protocol: :https)
+    else
+      options
+    end
   end
 
 end

--- a/app/views/shared/_citations.html.erb
+++ b/app/views/shared/_citations.html.erb
@@ -36,7 +36,11 @@
   <% else %>
     <% @presenter.member_presenters.each_with_index do |member, index| %>
       <% if index == 0 %>
-        <meta name="citation_pdf_url" content="<%= member.download_url %>"/>
+        <% if member.respond_to?(:download_url) %>
+          <meta name="citation_pdf_url" content="<%= member.download_url %>"/>
+        <% else %>
+          <meta name="citation_pdf_url" content="<%= Hyrax::Engine.routes.url_helpers.download_url(member, host: request.host) if member.model_name.name == 'FileSet' %>"/>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>


### PR DESCRIPTION
- fixes a bug on the show page view that fails to generate a `download_url` for `citation_pdf_url` (used for Google Scholar) when a `representative_id` is not set and the only member or first member in the list is a `FileSet`
- added an update to process default_url_options with https on production only