### PR TITLE
Adjust margins and fix Admin layout.

### DIFF
--- a/app/assets/stylesheets/osu.scss
+++ b/app/assets/stylesheets/osu.scss
@@ -1,5 +1,14 @@
 @import 'osu_settings';
 
+/* Override Hyrax dashboard class. */
+.dashboard {
+  padding-top: 0px !important;
+}
+
+.dashboard #masthead {
+  position: relative !important;
+}
+
 .image-masthead .background-container {
   background-image: image-url('SA-Mast-Head.png') !important;
 }
@@ -9,13 +18,16 @@
 }
 
 #masthead .navbar-header {
-  height: 80px;
+  height: 100px;
 }
 
 #lower-banner-border-masthead {
   overflow: hidden;
   background: $osu-black;
-  padding: 10px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  padding-left: 15px;
+  padding-right: 10px;
 }
 
 #lower-banner-border-masthead h1 a {
@@ -46,7 +58,10 @@
 #logo img {
   border-style: none;
   display: inline-block;
-  margin: 10px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  margin-left: 0px;
+  margin-right: 10px;
   height: 60px;
 }
 

--- a/app/views/_logo.html.erb
+++ b/app/views/_logo.html.erb
@@ -1,4 +1,3 @@
-<a id="logo" class="navbar-brand" href="<%= hyrax.root_path %>" data-no-turbolink="true">
+<a id="logo" class="navbar-brand" href="https://oregonstate.edu" data-no-turbolink="true">
   <img src="<%= path_to_image('oregon-state-university-logo.svg') %>" class="osu-logo" alt="Oregon State University">
 </a>
-


### PR DESCRIPTION
Fixes #1126 
Fixes #1127 

Reduced left margin on OSU logo.
Added left padding to ScholarsArchive@OSU to match the logo and other elements.

Changed .dashboard masthead to have position:relative to match main layout. This also uncovered the lower-masthead-border-banner and fixed the overhang on the little menu collapse arrow and the Edit Work sidebar.

Changed OSU logo link to be https://oregonstate.edu

![screenshot from 2017-12-28 15-46-25](https://user-images.githubusercontent.com/2293544/34425956-5cba22b0-ebe6-11e7-885a-f161f197bf96.png)