### PR TITLE
Move Dataset form fields above fold.

### DIFF
--- a/app/forms/scholars_archive/dataset_form_behavior.rb
+++ b/app/forms/scholars_archive/dataset_form_behavior.rb
@@ -17,11 +17,11 @@ module ScholarsArchive
       self.required_fields -= [:keyword]
 
       def primary_terms
-        [:title, :alt_title, :creator, :academic_affiliation, :other_affiliation, :contributor, :abstract, :license, :resource_type, :doi, :dates_section, :bibliographic_citation, :in_series, :subject, :rights_statement] | super
+        [:title, :alt_title, :creator, :academic_affiliation, :other_affiliation, :contributor, :abstract, :license, :resource_type, :doi, :dates_section, :bibliographic_citation, :in_series, :subject, :rights_statement, :nested_related_items, :hydrologic_unit_code, :geo_section, :funding_statement, :publisher, :peerreviewed, :language, :digitization_spec, :replaces, :additional_information] | super
       end
 
       def secondary_terms
-        [:nested_related_items, :hydrologic_unit_code, :geo_section, :funding_statement, :publisher, :peerreviewed, :language, :digitization_spec, :replaces, :additional_information]
+        []
       end
 
       def self.date_terms

--- a/app/views/hyrax/base/_form_metadata.html.erb
+++ b/app/views/hyrax/base/_form_metadata.html.erb
@@ -1,22 +1,20 @@
-
-        <div class="form-instructions">
-          <p>The more descriptive information you provide the better we can serve your needs.</p>
-        </div>
         <div class="base-terms">
           <% f.object.primary_terms.each do |term| %>
             <%= render_edit_field_partial(term, f: f) %>
           <% end %>
         </div>
-        <%= link_to t('hyrax.works.form.additional_fields'),
-                    '#extended-terms',
-                    class: 'btn btn-default additional-fields',
-                    data: { toggle: 'collapse' },
-                    role: "button",
-                    'aria-expanded'=> "false",
-                    'aria-controls'=> "extended-terms" %>
-        <div id="extended-terms" class='collapse'>
-          <%= render 'form_media', f: f %>
-          <% f.object.secondary_terms.each do |term| %>
-            <%= render_edit_field_partial(term, f: f) %>
-          <% end %>
-        </div>
+        <% if f.object.display_additional_fields? %>
+          <%= link_to t('hyrax.works.form.additional_fields'),
+                      '#extended-terms',
+                      class: 'btn btn-default additional-fields',
+                      data: { toggle: 'collapse' },
+                      role: "button",
+                      'aria-expanded'=> "false",
+                      'aria-controls'=> "extended-terms" %>
+          <div id="extended-terms" class='collapse'>
+            <%= render 'form_media', f: f %>
+            <% f.object.secondary_terms.each do |term| %>
+              <%= render_edit_field_partial(term, f: f) %>
+            <% end %>
+          </div>
+        <% end %>


### PR DESCRIPTION
Fixes #1159 

Also copy in updated _form_metadata.html.erb changes from Hyrax, which doesn't show 'Additional Fields' if there are no secondary terms in a form.