### PR TITLE
Add CSS to use smaller facet label size.

### DIFF
--- a/app/assets/stylesheets/osu.scss
+++ b/app/assets/stylesheets/osu.scss
@@ -86,6 +86,10 @@
 
 }
 
+div.facets h3 {
+  font-size: 1.2em !important;
+}
+
 div#date_wrapper, div#geo_wrapper {
   padding-left: 1em;
 }


### PR DESCRIPTION
Fixes #1182 

Showing same CSS change:
![screenshot from 2018-01-25 15-18-53](https://user-images.githubusercontent.com/2293544/35418403-ddaef132-01e6-11e8-80e5-18aecb3a9005.png)
