### PR TITLE
tooltips for internal/external links and a little bugfix

### DIFF
--- a/app/assets/javascripts/tooltips.js
+++ b/app/assets/javascripts/tooltips.js
@@ -1,0 +1,15 @@
+//= require bootstrap
+
+$(document).on('ready turbolinks:load', function() {
+  var search_options = {
+    placement: 'top',
+    title: 'Search for this term in SA@OSU'
+  };
+
+  $('.metadata > .table a').not('.btn').tooltip(search_options);
+  $('li.attribute a').not('.btn').tooltip(search_options);
+  $('li.attribute a.btn').tooltip({
+    placement: 'top',
+    title: 'More information about this item'
+  });
+});

--- a/app/renderers/hyrax/renderers/search_and_external_link_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/search_and_external_link_attribute_renderer.rb
@@ -20,7 +20,7 @@ module Hyrax
               search_field: search_field, q: ERB::Util.h(query_hash['label'])
           )
           links << link_to(query_hash['label'], search_path) if query_hash['label'].present?
-          links << link_to('<span class="glyphicon glyphicon-new-window"></span>'.html_safe, query_hash['uri'], 'aria-label' => "Open link in new window", class: 'btn btn-defaul') if query_hash['uri'].present?
+          links << link_to('<span class="glyphicon glyphicon-new-window"></span>'.html_safe, query_hash['uri'], 'aria-label' => "Open link in new window", class: 'btn') if query_hash['uri'].present?
         end
 
         links.join('')

--- a/spec/renderers/hyrax/renderers/scholars_archive_nested_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/scholars_archive_nested_attribute_renderer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Hyrax::Renderers::ScholarsArchiveNestedAttributeRenderer do
       <th>Sholars archive nested</th>
       <td><ul class="tabular"><li class="attribute sholars_archive_nested">          <span itemprop="relatedLink" itemscope itemtype="http://schema.org/relatedLink">
                   <span itemprop="url">
-                    <a href="/catalog?q=#{label_q}&amp;search_field=nested_related_items_label_ssim">#{label}</a><a aria-label="Open link in new window" class="btn btn-defaul" href="#{uri}"><span class="glyphicon glyphicon-new-window"></span></a>
+                    <a href="/catalog?q=#{label_q}&amp;search_field=nested_related_items_label_ssim">#{label}</a><a aria-label="Open link in new window" class="btn" href="#{uri}"><span class="glyphicon glyphicon-new-window"></span></a>
                   </span>
                 </span>
       </li></ul></td>

--- a/spec/renderers/hyrax/renderers/search_and_external_link_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/search_and_external_link_attribute_renderer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hyrax::Renderers::SearchAndExternalLinkAttributeRenderer do
       %(
       <tr>
       <th>Search and external link</th>
-      <td><ul class="tabular"><li class="attribute search_and_external_link"><a href="/catalog?q=#{label_q}&search_field=academic_affiliation_label">#{label}</a><a aria-label="Open link in new window" class="btn btn-defaul" href="#{uri}"><span class="glyphicon glyphicon-new-window"></span></a></li></ul></td>
+      <td><ul class="tabular"><li class="attribute search_and_external_link"><a href="/catalog?q=#{label_q}&search_field=academic_affiliation_label">#{label}</a><a aria-label="Open link in new window" class="btn" href="#{uri}"><span class="glyphicon glyphicon-new-window"></span></a></li></ul></td>
       </tr>
       )
     end


### PR DESCRIPTION
fixes #1144 
Fixes a typo, but the mis-typed class name isn't desired anyhow (it gives a bad looking style otherwise)

![tooltips](https://user-images.githubusercontent.com/32885/35459329-7d4e559a-0294-11e8-8ca7-1a15048ec9f3.gif)
