### PR TITLE
allow creating works without files for admin users

### DIFF
--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -1,0 +1,57 @@
+<aside id="form-progress" class="form-progress panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title"><%= t("hyrax.works.progress.header") %></h3>
+  </div>
+  <div class="list-group">
+    <div class="list-group-item">
+      <fieldset>
+        <legend class="legend-save-work"><%= t('.requirements') %></legend>
+        <ul class="requirements">
+          <li class="incomplete" id="required-metadata"><%= t('.required_descriptions') %></li>
+          <% if Hyrax.config.work_requires_files? && !current_user.admin? %>
+            <li class="incomplete" id="required-files"><%= t('.required_files') %></li>
+          <% end %>
+          <% if Flipflop.active_deposit_agreement_acceptance? %>
+            <li class="incomplete" id="required-agreement"><%= t('.required_agreement') %></li>
+          <% end %>
+        </ul>
+      </fieldset>
+    </div>
+
+    <div class="set-access-controls list-group-item">
+      <%= render 'form_visibility_component', f: f %>
+    </div>
+    <% if Flipflop.proxy_deposit? && current_user.can_make_deposits_for.any? %>
+      <div class="list-group-item">
+        <%= f.input :on_behalf_of, collection: current_user.can_make_deposits_for.map(&:user_key), prompt: "Yourself" %>
+      </div>
+    <% end %>
+  </div>
+  <div class="panel-footer text-center">
+    <% if ::Flipflop.show_deposit_agreement? %>
+      <% if ::Flipflop.active_deposit_agreement_acceptance? %>
+        <label>
+          <%= check_box_tag 'agreement', 1, f.object.agreement_accepted, required: true %>
+          <%= t('hyrax.active_consent_to_agreement') %><br>
+          <%= link_to t('hyrax.pages.tabs.agreement_page'),
+                      hyrax.agreement_path,
+                      target: '_blank' %>
+        </label>
+      <% else %>
+        <%= t('hyrax.passive_consent_to_agreement') %><br>
+        <%= link_to t('hyrax.pages.tabs.agreement_page'),
+                    hyrax.agreement_path,
+                    target: '_blank' %>
+      <% end %>
+    <% end %>
+    <br>
+    <% cancel_path = f.object.persisted? ? polymorphic_path([main_app, f.object]) : hyrax.my_works_path %>
+    <%= link_to t(:'helpers.action.cancel'),
+                cancel_path,
+                class: 'btn btn-default' %>
+    <%# TODO: If we start using ActionCable, we could listen for object updates and
+              alert the user that the object has changed by someone else %>
+    <%= f.input Hyrax::Actors::OptimisticLockValidator.version_field, as: :hidden if f.object.persisted? %>
+    <%= f.submit class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
+  </div>
+</aside>


### PR DESCRIPTION
added admin check `!current_user.admin?` (user not an admin) in the form progress (default value for `work_requires_files` is true), so the view should skip the file requirement if the user is not an admin:
`<% if Hyrax.config.work_requires_files? && !current_user.admin? %>`

