### PR TITLE
added scholars archive shares behavior to handle template not found

### DIFF
--- a/app/controllers/concerns/scholars_archive/my_shares_behavior.rb
+++ b/app/controllers/concerns/scholars_archive/my_shares_behavior.rb
@@ -1,0 +1,14 @@
+module ScholarsArchive
+  module MySharesBehavior
+    extend ActiveSupport::Concern
+
+    included do
+      # We are adding custom_redirect here to prevent a template-not-found error for dashboard/shares path for now
+      # A related issue has been reported here https://github.com/samvera/hyrax/issues/2767
+      # TODO: Once hyrax/issues/2767 is resolved, remove custom_redirect and ScholarsArchive::MySharesBehavior as well if not needed
+      def custom_redirect
+        redirect_to hyrax.my_works_path and return
+      end
+    end
+  end
+end

--- a/app/controllers/scholars_archive/shares_controller.rb
+++ b/app/controllers/scholars_archive/shares_controller.rb
@@ -1,0 +1,6 @@
+module ScholarsArchive
+  class SharesController < Hyrax::My::SharesController
+    include ScholarsArchive::MySharesBehavior
+    before_action :custom_redirect, only: :index
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
   get '/downloads/:id(.:format)', to: 'scholars_archive/downloads#show', as: 'download'
   get '/single_use_link/download/:id(.:format)', to: 'scholars_archive/single_use_links_viewer#download', as: 'download_single_use_link'
+  get '/dashboard/shares(.:format)', to: 'scholars_archive/shares#index', as: 'dashboard_shares'
   mount Blacklight::Engine => '/'
 
   concern :searchable, Blacklight::Routes::Searchable.new


### PR DESCRIPTION
fixes #1283 

- We are adding a Scholars Archive behavior for `SharesController`, which includes `custom_redirect`
- `custom_redirect` could be used to prevent a template-not-found error for `dashboard/shares` path for now (We are redirecting from `dashboard/shares` to `dashboard/my/works`, which is the default path for regular users)
- A related issue has been reported in hyrax here https://github.com/samvera/hyrax/issues/2767
- Once hyrax/issues/2767 is resolved, we can remove the `custom_redirect` and `ScholarsArchive::MySharesBehavior` as well if not needed in the end