### PR TITLE
sets link text to an identifiable color for the help text

### DIFF
--- a/app/assets/stylesheets/osu.scss
+++ b/app/assets/stylesheets/osu.scss
@@ -313,5 +313,8 @@ li.attribute.abstract a {
     text-align: center;
     width: 100%;
     float: left;
+    a {
+      color: $osu-orange !important;
+    }
   }
 }


### PR DESCRIPTION
ref #1311 (not fully addressed throughout the application)

This sets the link color, for the work type modal help text, to osu orange until #1311 is solved throughout the application.