### PR TITLE
Adds hidden values to the end for admin users.

### DIFF
--- a/app/forms/scholars_archive/default_work_form_behavior.rb
+++ b/app/forms/scholars_archive/default_work_form_behavior.rb
@@ -24,10 +24,9 @@ module ScholarsArchive
       end
 
       def secondary_terms
-        if current_ability.current_user.admin?
-          [:nested_related_items, :hydrologic_unit_code, :geo_section, :funding_statement, :publisher, :peerreviewed, :conference_location, :conference_name, :conference_section, :language, :file_format, :file_extent, :digitization_spec, :replaces, :additional_information, :isbn, :issn, :keyword, :source, :funding_body, :dspace_community, :dspace_collection]
-        else
-          [:nested_related_items, :hydrologic_unit_code, :geo_section, :funding_statement, :publisher, :peerreviewed, :conference_location, :conference_name, :conference_section, :language, :file_format, :file_extent, :digitization_spec, :replaces, :additional_information, :isbn, :issn]
+          t = [:nested_related_items, :hydrologic_unit_code, :geo_section, :funding_statement, :publisher, :peerreviewed, :conference_location, :conference_name, :conference_section, :language, :file_format, :file_extent, :digitization_spec, :replaces, :additional_information, :isbn, :issn]
+          t << [:keyword, :source, :funding_body, :dspace_community, :dspace_collection]
+          t.flatten
         end
       end
 

--- a/app/forms/scholars_archive/default_work_form_behavior.rb
+++ b/app/forms/scholars_archive/default_work_form_behavior.rb
@@ -24,10 +24,9 @@ module ScholarsArchive
       end
 
       def secondary_terms
-          t = [:nested_related_items, :hydrologic_unit_code, :geo_section, :funding_statement, :publisher, :peerreviewed, :conference_location, :conference_name, :conference_section, :language, :file_format, :file_extent, :digitization_spec, :replaces, :additional_information, :isbn, :issn]
-          t << [:keyword, :source, :funding_body, :dspace_community, :dspace_collection]
-          t.flatten
-        end
+        t = [:nested_related_items, :hydrologic_unit_code, :geo_section, :funding_statement, :publisher, :peerreviewed, :conference_location, :conference_name, :conference_section, :language, :file_format, :file_extent, :digitization_spec, :replaces, :additional_information, :isbn, :issn]
+        t << [:keyword, :source, :funding_body, :dspace_community, :dspace_collection]
+        t.flatten
       end
 
       def self.date_terms

--- a/app/forms/scholars_archive/default_work_form_behavior.rb
+++ b/app/forms/scholars_archive/default_work_form_behavior.rb
@@ -25,7 +25,7 @@ module ScholarsArchive
 
       def secondary_terms
         t = [:nested_related_items, :hydrologic_unit_code, :geo_section, :funding_statement, :publisher, :peerreviewed, :conference_location, :conference_name, :conference_section, :language, :file_format, :file_extent, :digitization_spec, :replaces, :additional_information, :isbn, :issn]
-        t << [:keyword, :source, :funding_body, :dspace_community, :dspace_collection]
+        t << [:keyword, :source, :funding_body, :dspace_community, :dspace_collection] if current_ability.current_user.admin?
         t.flatten
       end
 

--- a/app/forms/scholars_archive/default_work_form_behavior.rb
+++ b/app/forms/scholars_archive/default_work_form_behavior.rb
@@ -24,7 +24,11 @@ module ScholarsArchive
       end
 
       def secondary_terms
-        [:nested_related_items, :hydrologic_unit_code, :geo_section, :funding_statement, :publisher, :peerreviewed, :conference_location, :conference_name, :conference_section, :language, :file_format, :file_extent, :digitization_spec, :replaces, :additional_information, :isbn, :issn]
+        if current_ability.current_user.admin?
+          [:nested_related_items, :hydrologic_unit_code, :geo_section, :funding_statement, :publisher, :peerreviewed, :conference_location, :conference_name, :conference_section, :language, :file_format, :file_extent, :digitization_spec, :replaces, :additional_information, :isbn, :issn, :keyword, :source, :funding_body, :dspace_community, :dspace_collection]
+        else
+          [:nested_related_items, :hydrologic_unit_code, :geo_section, :funding_statement, :publisher, :peerreviewed, :conference_location, :conference_name, :conference_section, :language, :file_format, :file_extent, :digitization_spec, :replaces, :additional_information, :isbn, :issn]
+        end
       end
 
       def self.date_terms

--- a/spec/forms/hyrax/administrative_report_or_publication_form_spec.rb
+++ b/spec/forms/hyrax/administrative_report_or_publication_form_spec.rb
@@ -1,8 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::AdministrativeReportOrPublicationForm do
-
+  let(:user) do
+    User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
+  end
   let(:new_form) { described_class.new(AdministrativeReportOrPublication.new, nil, double("Controller")) }
+  let(described_class).receive(:current_ability).and_return(user)
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:doi, :alt_title, :abstract, :license, :based_near, :resource_type, :date_available, :date_copyright, :date_issued, :date_collected, :date_valid, :date_reviewed, :date_accepted, :replaces, :hydrologic_unit_code, :funding_body, :funding_statement, :in_series, :tableofcontents, :bibliographic_citation, :peerreviewed, :additional_information, :digitization_spec, :file_extent, :file_format, :dspace_community, :dspace_collection]

--- a/spec/forms/hyrax/administrative_report_or_publication_form_spec.rb
+++ b/spec/forms/hyrax/administrative_report_or_publication_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::AdministrativeReportOrPublicationForm do
   let(:new_form) { described_class.new(AdministrativeReportOrPublication.new, nil, double("Controller")) }
 
   before do
-    allow(described_class).receive(:current_ability).and_return(user)
+    allow(described_class).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/administrative_report_or_publication_form_spec.rb
+++ b/spec/forms/hyrax/administrative_report_or_publication_form_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe Hyrax::AdministrativeReportOrPublicationForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   let(:new_form) { described_class.new(AdministrativeReportOrPublication.new, nil, double("Controller")) }
+  let(:ability) {double("Ability")}
 
   before do
-    allow(new_form).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/administrative_report_or_publication_form_spec.rb
+++ b/spec/forms/hyrax/administrative_report_or_publication_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::AdministrativeReportOrPublicationForm do
   let(:new_form) { described_class.new(AdministrativeReportOrPublication.new, nil, double("Controller")) }
 
   before do
-    allow(described_class).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/administrative_report_or_publication_form_spec.rb
+++ b/spec/forms/hyrax/administrative_report_or_publication_form_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe Hyrax::AdministrativeReportOrPublicationForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   let(:new_form) { described_class.new(AdministrativeReportOrPublication.new, nil, double("Controller")) }
-  let(described_class).receive(:current_ability).and_return(user)
+
+  before do
+    allow(described_class).receive(:current_ability).and_return(user)
+  end
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:doi, :alt_title, :abstract, :license, :based_near, :resource_type, :date_available, :date_copyright, :date_issued, :date_collected, :date_valid, :date_reviewed, :date_accepted, :replaces, :hydrologic_unit_code, :funding_body, :funding_statement, :in_series, :tableofcontents, :bibliographic_citation, :peerreviewed, :additional_information, :digitization_spec, :file_extent, :file_format, :dspace_community, :dspace_collection]

--- a/spec/forms/hyrax/article_form_spec.rb
+++ b/spec/forms/hyrax/article_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hyrax::ArticleForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/article_form_spec.rb
+++ b/spec/forms/hyrax/article_form_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Hyrax::ArticleForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
-  let(described_class).receive(:current_ability).and_return(user)
+  before do
+    allow(described_class).receive(:current_ability).and_return(user)
+  end
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:resource_type, :editor, :has_volume, :has_number, :conference_location, :conference_name, :conference_section, :has_journal, :is_referenced_by]

--- a/spec/forms/hyrax/article_form_spec.rb
+++ b/spec/forms/hyrax/article_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hyrax::ArticleForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).receive(:current_ability).and_return(user)
+    allow(described_class).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/article_form_spec.rb
+++ b/spec/forms/hyrax/article_form_spec.rb
@@ -5,8 +5,11 @@ RSpec.describe Hyrax::ArticleForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
+  let(:ability) {double("Ability")}
+
   before do
-    allow(new_form).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/article_form_spec.rb
+++ b/spec/forms/hyrax/article_form_spec.rb
@@ -1,8 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::ArticleForm do
-
   let(:new_form) { described_class.new(Article.new, nil, double("Controller")) }
+  let(:user) do
+    User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
+  end
+  let(described_class).receive(:current_ability).and_return(user)
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:resource_type, :editor, :has_volume, :has_number, :conference_location, :conference_name, :conference_section, :has_journal, :is_referenced_by]

--- a/spec/forms/hyrax/conference_proceedings_or_journal_form_spec.rb
+++ b/spec/forms/hyrax/conference_proceedings_or_journal_form_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe Hyrax::ConferenceProceedingsOrJournalForm do
 
   let(:new_form) { described_class.new(ConferenceProceedingsOrJournal.new, nil, double("Controller")) }
+  let(:user) do
+    User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
+  end
+  let(described_class).receive(:current_ability).and_return(user)
+
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:resource_type, :editor, :has_volume, :has_number, :conference_location, :conference_name, :conference_section, :has_journal, :is_referenced_by, :isbn]

--- a/spec/forms/hyrax/conference_proceedings_or_journal_form_spec.rb
+++ b/spec/forms/hyrax/conference_proceedings_or_journal_form_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe Hyrax::ConferenceProceedingsOrJournalForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
-  let(described_class).receive(:current_ability).and_return(user)
-
+  before do
+    allow(described_class).receive(:current_ability).and_return(user)
+  end
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:resource_type, :editor, :has_volume, :has_number, :conference_location, :conference_name, :conference_section, :has_journal, :is_referenced_by, :isbn]

--- a/spec/forms/hyrax/conference_proceedings_or_journal_form_spec.rb
+++ b/spec/forms/hyrax/conference_proceedings_or_journal_form_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe Hyrax::ConferenceProceedingsOrJournalForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
+  let(:ability) {double("Ability")}
   before do
-    allow(new_form).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/conference_proceedings_or_journal_form_spec.rb
+++ b/spec/forms/hyrax/conference_proceedings_or_journal_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::ConferenceProceedingsOrJournalForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).receive(:current_ability).and_return(user)
+    allow(described_class).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/conference_proceedings_or_journal_form_spec.rb
+++ b/spec/forms/hyrax/conference_proceedings_or_journal_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::ConferenceProceedingsOrJournalForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/dataset_form_spec.rb
+++ b/spec/forms/hyrax/dataset_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::DatasetForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/dataset_form_spec.rb
+++ b/spec/forms/hyrax/dataset_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::DatasetForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).receive(:current_ability).and_return(user)
+    allow(described_class).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/dataset_form_spec.rb
+++ b/spec/forms/hyrax/dataset_form_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe Hyrax::DatasetForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
+  let(:ability) {double("Ability")}
+
   before do
-    allow(new_form).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/dataset_form_spec.rb
+++ b/spec/forms/hyrax/dataset_form_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Hyrax::DatasetForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
-  let(described_class).receive(:current_ability).and_return(user)
+  before do
+    allow(described_class).receive(:current_ability).and_return(user)
+  end
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:doi, :alt_title, :abstract, :license, :based_near, :resource_type, :date_available, :date_copyright, :date_issued, :date_collected, :date_reviewed, :date_valid, :date_accepted, :replaces, :hydrologic_unit_code, :funding_body, :funding_statement, :in_series, :tableofcontents, :bibliographic_citation, :peerreviewed, :additional_information, :digitization_spec, :file_extent, :file_format, :dspace_community, :dspace_collection]

--- a/spec/forms/hyrax/dataset_form_spec.rb
+++ b/spec/forms/hyrax/dataset_form_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Hyrax::DatasetForm do
 
   let(:new_form) { described_class.new(Dataset.new, nil, double("Controller")) }
+  let(:user) do
+    User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
+  end
+  let(described_class).receive(:current_ability).and_return(user)
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:doi, :alt_title, :abstract, :license, :based_near, :resource_type, :date_available, :date_copyright, :date_issued, :date_collected, :date_reviewed, :date_valid, :date_accepted, :replaces, :hydrologic_unit_code, :funding_body, :funding_statement, :in_series, :tableofcontents, :bibliographic_citation, :peerreviewed, :additional_information, :digitization_spec, :file_extent, :file_format, :dspace_community, :dspace_collection]

--- a/spec/forms/hyrax/default_form_spec.rb
+++ b/spec/forms/hyrax/default_form_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe Hyrax::DefaultForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
+  let(:ability) {double("Ability")}
+
   before do
-    allow(new_form).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/default_form_spec.rb
+++ b/spec/forms/hyrax/default_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::DefaultForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).receive(:current_ability).and_return(user)
+    allow(described_class).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/default_form_spec.rb
+++ b/spec/forms/hyrax/default_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::DefaultForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/default_form_spec.rb
+++ b/spec/forms/hyrax/default_form_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Hyrax::DefaultForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
-  let(described_class).receive(:current_ability).and_return(user)
+  before do
+    allow(described_class).receive(:current_ability).and_return(user)
+  end
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:isbn, :issn, :doi, :alt_title, :abstract, :license, :based_near, :resource_type, :date_available, :date_copyright, :date_issued, :date_collected, :date_reviewed, :date_valid, :date_accepted, :replaces, :hydrologic_unit_code, :funding_body, :funding_statement, :in_series, :tableofcontents, :bibliographic_citation, :peerreviewed, :additional_information, :digitization_spec, :file_extent, :file_format, :dspace_community, :dspace_collection, :conference_location, :conference_name, :conference_section]

--- a/spec/forms/hyrax/default_form_spec.rb
+++ b/spec/forms/hyrax/default_form_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Hyrax::DefaultForm do
 
   let(:new_form) { described_class.new(Default.new, nil, double("Controller")) }
+  let(:user) do
+    User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
+  end
+  let(described_class).receive(:current_ability).and_return(user)
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:isbn, :issn, :doi, :alt_title, :abstract, :license, :based_near, :resource_type, :date_available, :date_copyright, :date_issued, :date_collected, :date_reviewed, :date_valid, :date_accepted, :replaces, :hydrologic_unit_code, :funding_body, :funding_statement, :in_series, :tableofcontents, :bibliographic_citation, :peerreviewed, :additional_information, :digitization_spec, :file_extent, :file_format, :dspace_community, :dspace_collection, :conference_location, :conference_name, :conference_section]

--- a/spec/forms/hyrax/eesc_publication_form_spec.rb
+++ b/spec/forms/hyrax/eesc_publication_form_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Hyrax::EescPublicationForm do
 
   let(:new_form) { described_class.new(EescPublication.new, nil, double("Controller")) }
+  let(:user) do
+    User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
+  end
+  let(described_class).receive(:current_ability).and_return(user)
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:doi, :alt_title, :abstract, :license, :based_near, :resource_type, :date_available, :date_copyright, :date_issued, :date_collected, :date_reviewed, :date_valid, :date_accepted, :replaces, :hydrologic_unit_code, :funding_body, :funding_statement, :in_series, :tableofcontents, :bibliographic_citation, :peerreviewed, :additional_information, :digitization_spec, :file_extent, :file_format, :dspace_community, :dspace_collection]

--- a/spec/forms/hyrax/eesc_publication_form_spec.rb
+++ b/spec/forms/hyrax/eesc_publication_form_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe Hyrax::EescPublicationForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
+  let(:ability) {double("Ability")}
+
   before do
-    allow(new_form).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
   end
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:doi, :alt_title, :abstract, :license, :based_near, :resource_type, :date_available, :date_copyright, :date_issued, :date_collected, :date_reviewed, :date_valid, :date_accepted, :replaces, :hydrologic_unit_code, :funding_body, :funding_statement, :in_series, :tableofcontents, :bibliographic_citation, :peerreviewed, :additional_information, :digitization_spec, :file_extent, :file_format, :dspace_community, :dspace_collection]

--- a/spec/forms/hyrax/eesc_publication_form_spec.rb
+++ b/spec/forms/hyrax/eesc_publication_form_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe Hyrax::EescPublicationForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
-  let(described_class).receive(:current_ability).and_return(user)
-
+  before do
+    allow(described_class).receive(:current_ability).and_return(user)
+  end
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:doi, :alt_title, :abstract, :license, :based_near, :resource_type, :date_available, :date_copyright, :date_issued, :date_collected, :date_reviewed, :date_valid, :date_accepted, :replaces, :hydrologic_unit_code, :funding_body, :funding_statement, :in_series, :tableofcontents, :bibliographic_citation, :peerreviewed, :additional_information, :digitization_spec, :file_extent, :file_format, :dspace_community, :dspace_collection]
   end

--- a/spec/forms/hyrax/eesc_publication_form_spec.rb
+++ b/spec/forms/hyrax/eesc_publication_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::EescPublicationForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(user)
   end
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:doi, :alt_title, :abstract, :license, :based_near, :resource_type, :date_available, :date_copyright, :date_issued, :date_collected, :date_reviewed, :date_valid, :date_accepted, :replaces, :hydrologic_unit_code, :funding_body, :funding_statement, :in_series, :tableofcontents, :bibliographic_citation, :peerreviewed, :additional_information, :digitization_spec, :file_extent, :file_format, :dspace_community, :dspace_collection]

--- a/spec/forms/hyrax/eesc_publication_form_spec.rb
+++ b/spec/forms/hyrax/eesc_publication_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::EescPublicationForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).receive(:current_ability).and_return(user)
+    allow(described_class).to receive(:current_ability).and_return(user)
   end
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:doi, :alt_title, :abstract, :license, :based_near, :resource_type, :date_available, :date_copyright, :date_issued, :date_collected, :date_reviewed, :date_valid, :date_accepted, :replaces, :hydrologic_unit_code, :funding_body, :funding_statement, :in_series, :tableofcontents, :bibliographic_citation, :peerreviewed, :additional_information, :digitization_spec, :file_extent, :file_format, :dspace_community, :dspace_collection]

--- a/spec/forms/hyrax/graduate_project_form_spec.rb
+++ b/spec/forms/hyrax/graduate_project_form_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Hyrax::GraduateProjectForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/graduate_project_form_spec.rb
+++ b/spec/forms/hyrax/graduate_project_form_spec.rb
@@ -3,9 +3,13 @@ require 'rails_helper'
 RSpec.describe Hyrax::GraduateProjectForm do
 
   let(:new_form) { described_class.new(GraduateProject.new, nil, double("Controller")) }
+  let(:user) do
+    User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
+  end
+  let(described_class).receive(:current_ability).and_return(user)
 
   it "responds to terms with the proper list of terms" do
-    expect(described_class.terms).to include *[:degree_level, :degree_name, :degree_field, :degree_grantors, :contributor_advisor, :contributor_committeemember, :graduation_year, :degree_discipline]  
+    expect(described_class.terms).to include *[:degree_level, :degree_name, :degree_field, :degree_grantors, :contributor_advisor, :contributor_committeemember, :graduation_year, :degree_discipline]
   end
   it "has the proper required fields" do
     expect(described_class.required_fields).to include *[:degree_level, :degree_name, :degree_field, :degree_grantors, :graduation_year]

--- a/spec/forms/hyrax/graduate_project_form_spec.rb
+++ b/spec/forms/hyrax/graduate_project_form_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Hyrax::GraduateProjectForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
+  let(:ability) {double("Ability")}
+
   before do
     allow(new_form).to receive(:current_ability).and_return(ability)
     allow(ability).to receive(:current_user).and_return(user)

--- a/spec/forms/hyrax/graduate_project_form_spec.rb
+++ b/spec/forms/hyrax/graduate_project_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::GraduateProjectForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).receive(:current_ability).and_return(user)
+    allow(described_class).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/graduate_project_form_spec.rb
+++ b/spec/forms/hyrax/graduate_project_form_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Hyrax::GraduateProjectForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
-  let(described_class).receive(:current_ability).and_return(user)
+  before do
+    allow(described_class).receive(:current_ability).and_return(user)
+  end
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:degree_level, :degree_name, :degree_field, :degree_grantors, :contributor_advisor, :contributor_committeemember, :graduation_year, :degree_discipline]

--- a/spec/forms/hyrax/graduate_thesis_or_dissertation_form_spec.rb
+++ b/spec/forms/hyrax/graduate_thesis_or_dissertation_form_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe Hyrax::GraduateThesisOrDissertationForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
+  let(:ability) {double("Ability")}
+
   before do
-    allow(new_form).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/graduate_thesis_or_dissertation_form_spec.rb
+++ b/spec/forms/hyrax/graduate_thesis_or_dissertation_form_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Hyrax::GraduateThesisOrDissertationForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
-  let(described_class).receive(:current_ability).and_return(user)
+  before do
+    allow(described_class).receive(:current_ability).and_return(user)
+  end
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:degree_level, :degree_name, :degree_field, :degree_grantors, :contributor_advisor, :contributor_committeemember, :graduation_year, :degree_discipline]

--- a/spec/forms/hyrax/graduate_thesis_or_dissertation_form_spec.rb
+++ b/spec/forms/hyrax/graduate_thesis_or_dissertation_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::GraduateThesisOrDissertationForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/graduate_thesis_or_dissertation_form_spec.rb
+++ b/spec/forms/hyrax/graduate_thesis_or_dissertation_form_spec.rb
@@ -3,9 +3,13 @@ require 'rails_helper'
 RSpec.describe Hyrax::GraduateThesisOrDissertationForm do
 
   let(:new_form) { described_class.new(GraduateThesisOrDissertation.new, nil, double("Controller")) }
+  let(:user) do
+    User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
+  end
+  let(described_class).receive(:current_ability).and_return(user)
 
   it "responds to terms with the proper list of terms" do
-    expect(described_class.terms).to include *[:degree_level, :degree_name, :degree_field, :degree_grantors, :contributor_advisor, :contributor_committeemember, :graduation_year, :degree_discipline]  
+    expect(described_class.terms).to include *[:degree_level, :degree_name, :degree_field, :degree_grantors, :contributor_advisor, :contributor_committeemember, :graduation_year, :degree_discipline]
   end
   it "has the proper required fields" do
     expect(described_class.required_fields).to include *[:degree_level, :degree_name, :degree_field, :degree_grantors, :graduation_year]

--- a/spec/forms/hyrax/graduate_thesis_or_dissertation_form_spec.rb
+++ b/spec/forms/hyrax/graduate_thesis_or_dissertation_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::GraduateThesisOrDissertationForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).receive(:current_ability).and_return(user)
+    allow(described_class).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/open_educational_resource_form_spec.rb
+++ b/spec/forms/hyrax/open_educational_resource_form_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Hyrax::OpenEducationalResourceForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
-  let(described_class).receive(:current_ability).and_return(user)
+  before do
+    allow(described_class).receive(:current_ability).and_return(user)
+  end
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:resource_type, :is_based_on_url, :interactivity_type, :learning_resource_type, :typical_age_range, :time_required, :duration]

--- a/spec/forms/hyrax/open_educational_resource_form_spec.rb
+++ b/spec/forms/hyrax/open_educational_resource_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::OpenEducationalResourceForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/open_educational_resource_form_spec.rb
+++ b/spec/forms/hyrax/open_educational_resource_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::OpenEducationalResourceForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).receive(:current_ability).and_return(user)
+    allow(described_class).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/open_educational_resource_form_spec.rb
+++ b/spec/forms/hyrax/open_educational_resource_form_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe Hyrax::OpenEducationalResourceForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
+  let(:ability) {double("Ability")}
+
   before do
-    allow(new_form).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/open_educational_resource_form_spec.rb
+++ b/spec/forms/hyrax/open_educational_resource_form_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Hyrax::OpenEducationalResourceForm do
 
   let(:new_form) { described_class.new(OpenEducationalResource.new, nil, double("Controller")) }
+  let(:user) do
+    User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
+  end
+  let(described_class).receive(:current_ability).and_return(user)
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:resource_type, :is_based_on_url, :interactivity_type, :learning_resource_type, :typical_age_range, :time_required, :duration]

--- a/spec/forms/hyrax/purchased_e_resource_form_spec.rb
+++ b/spec/forms/hyrax/purchased_e_resource_form_spec.rb
@@ -7,7 +7,7 @@ let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/purchased_e_resource_form_spec.rb
+++ b/spec/forms/hyrax/purchased_e_resource_form_spec.rb
@@ -7,7 +7,7 @@ let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).receive(:current_ability).and_return(user)
+    allow(described_class).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/purchased_e_resource_form_spec.rb
+++ b/spec/forms/hyrax/purchased_e_resource_form_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Hyrax::PurchasedEResourceForm do
 let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
-  let(described_class).receive(:current_ability).and_return(user)
+  before do
+    allow(described_class).receive(:current_ability).and_return(user)
+  end
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:resource_type, :editor, :has_volume, :has_number, :conference_location, :conference_name, :conference_section, :has_journal, :is_referenced_by]

--- a/spec/forms/hyrax/purchased_e_resource_form_spec.rb
+++ b/spec/forms/hyrax/purchased_e_resource_form_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe Hyrax::PurchasedEResourceForm do
 let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
+  let(:ability) {double("Ability")}
+
   before do
-    allow(new_form).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/purchased_e_resource_form_spec.rb
+++ b/spec/forms/hyrax/purchased_e_resource_form_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Hyrax::PurchasedEResourceForm do
 
   let(:new_form) { described_class.new(PurchasedEResource.new, nil, double("Controller")) }
+let(:user) do
+    User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
+  end
+  let(described_class).receive(:current_ability).and_return(user)
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:resource_type, :editor, :has_volume, :has_number, :conference_location, :conference_name, :conference_section, :has_journal, :is_referenced_by]

--- a/spec/forms/hyrax/technical_report_form_spec.rb
+++ b/spec/forms/hyrax/technical_report_form_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Hyrax::TechnicalReportForm do
 
   let(:new_form) { described_class.new(TechnicalReport.new, nil, double("Controller")) }
+  let(:user) do
+    User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
+  end
+  let(described_class).receive(:current_ability).and_return(user)
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:doi, :alt_title, :abstract, :license, :based_near, :resource_type, :date_available, :date_copyright, :date_issued, :date_collected, :date_reviewed, :date_valid, :date_accepted, :replaces, :hydrologic_unit_code, :funding_body, :funding_statement, :in_series, :tableofcontents, :bibliographic_citation, :peerreviewed, :additional_information, :digitization_spec, :file_extent, :file_format, :dspace_community, :dspace_collection]

--- a/spec/forms/hyrax/technical_report_form_spec.rb
+++ b/spec/forms/hyrax/technical_report_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::TechnicalReportForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).receive(:current_ability).and_return(user)
+    allow(described_class).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/technical_report_form_spec.rb
+++ b/spec/forms/hyrax/technical_report_form_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe Hyrax::TechnicalReportForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
+  let(:ability) {double("Ability")}
+
   before do
-    allow(new_form).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/technical_report_form_spec.rb
+++ b/spec/forms/hyrax/technical_report_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::TechnicalReportForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/technical_report_form_spec.rb
+++ b/spec/forms/hyrax/technical_report_form_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Hyrax::TechnicalReportForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
-  let(described_class).receive(:current_ability).and_return(user)
+  before do
+    allow(described_class).receive(:current_ability).and_return(user)
+  end
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:doi, :alt_title, :abstract, :license, :based_near, :resource_type, :date_available, :date_copyright, :date_issued, :date_collected, :date_reviewed, :date_valid, :date_accepted, :replaces, :hydrologic_unit_code, :funding_body, :funding_statement, :in_series, :tableofcontents, :bibliographic_citation, :peerreviewed, :additional_information, :digitization_spec, :file_extent, :file_format, :dspace_community, :dspace_collection]

--- a/spec/forms/hyrax/undergraduate_thesis_or_project_form_spec.rb
+++ b/spec/forms/hyrax/undergraduate_thesis_or_project_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::UndergraduateThesisOrProjectForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).receive(:current_ability).and_return(user)
+    allow(described_class).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/undergraduate_thesis_or_project_form_spec.rb
+++ b/spec/forms/hyrax/undergraduate_thesis_or_project_form_spec.rb
@@ -3,9 +3,13 @@ require 'rails_helper'
 RSpec.describe Hyrax::UndergraduateThesisOrProjectForm do
 
   let(:new_form) { described_class.new(UndergraduateThesisOrProject.new, nil, double("Controller")) }
+  let(:user) do
+    User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
+  end
+  let(described_class).receive(:current_ability).and_return(user)
 
   it "responds to terms with the proper list of terms" do
-    expect(described_class.terms).to include *[:degree_level, :degree_name, :degree_field, :degree_grantors, :contributor_advisor, :contributor_committeemember, :graduation_year, :degree_discipline]  
+    expect(described_class.terms).to include *[:degree_level, :degree_name, :degree_field, :degree_grantors, :contributor_advisor, :contributor_committeemember, :graduation_year, :degree_discipline]
   end
 
   it "has the proper primary terms" do

--- a/spec/forms/hyrax/undergraduate_thesis_or_project_form_spec.rb
+++ b/spec/forms/hyrax/undergraduate_thesis_or_project_form_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe Hyrax::UndergraduateThesisOrProjectForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
+  let(:ability) {double("Ability")}
+
   before do
-    allow(new_form).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/forms/hyrax/undergraduate_thesis_or_project_form_spec.rb
+++ b/spec/forms/hyrax/undergraduate_thesis_or_project_form_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Hyrax::UndergraduateThesisOrProjectForm do
   let(:user) do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
-  let(described_class).receive(:current_ability).and_return(user)
+  before do
+    allow(described_class).receive(:current_ability).and_return(user)
+  end
 
   it "responds to terms with the proper list of terms" do
     expect(described_class.terms).to include *[:degree_level, :degree_name, :degree_field, :degree_grantors, :contributor_advisor, :contributor_committeemember, :graduation_year, :degree_discipline]

--- a/spec/forms/hyrax/undergraduate_thesis_or_project_form_spec.rb
+++ b/spec/forms/hyrax/undergraduate_thesis_or_project_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::UndergraduateThesisOrProjectForm do
     User.new(email: 'test@example.com', guest: false) { |u| u.save!(validate: false)}
   end
   before do
-    allow(described_class).to receive(:current_ability).and_return(user)
+    allow(new_form).to receive(:current_ability).and_return(user)
   end
 
   it "responds to terms with the proper list of terms" do

--- a/spec/views/hyrax/base/_form_instructions_spec.rb
+++ b/spec/views/hyrax/base/_form_instructions_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe 'hyrax/base/_form.erb', type: :view do
     stub_template('hyrax/base/_form_relationships.html.erb' => "Relationships")
     allow(work).to receive(:new_record?).and_return(true)
     allow(work).to receive(:member_ids).and_return([1, 2])
+    allow(ability).to receive(:current_user).and_return(current_user)
     allow(curation_concern.model_name).to receive(:name).and_return('default')
     allow(controller).to receive(:current_user).and_return(current_user)
     assign(:form, form)


### PR DESCRIPTION
Fixes #1157 

<img width="1391" alt="screen shot 2018-04-10 at 12 54 53 pm" src="https://user-images.githubusercontent.com/6424683/38580376-a0fe1c6e-3cbe-11e8-8f56-04e7519f7268.png">

This adds hidden fields to the end if a user is an admin. Since it lives on default it will show up on all the work types.