### PR TITLE
added field_validation_service

### DIFF
--- a/app/actors/scholars_archive/actors/add_other_field_option_actor.rb
+++ b/app/actors/scholars_archive/actors/add_other_field_option_actor.rb
@@ -26,26 +26,27 @@ module ScholarsArchive
       def save_custom_option(env)
         puts "save custom option if any"
         if degree_present? (env)
-          if env.curation_concern.degree_field_other.present?
+          if env.curation_concern.degree_field_other.present? && is_valid_other_field_multiple?(env, :degree_field)
             puts "saving degree field other and notifying admin"
             all_new_entries = persist_multiple_other_entries(env, :degree_field)
             notify_admin(env, field: :degree_field, new_entries: all_new_entries)
           end
-          if env.curation_concern.degree_level_other.present?
+          if env.curation_concern.degree_level_other.present? && is_valid_other_field?(env, :degree_level)
             puts "degree level other and notifying admin"
             OtherOption.find_or_create_by(name: env.curation_concern.degree_level_other.to_s, work_id: env.curation_concern.id, property_name: :degree_level.to_s)
             notify_admin(env, field: :degree_level, new_entries: env.curation_concern.degree_level_other)
           end
-          if env.curation_concern.degree_name_other.present?
+          if env.curation_concern.degree_name_other.present? && is_valid_other_field_multiple?(env, :degree_name)
             puts "degree name other and notifying admin"
             all_new_entries = persist_multiple_other_entries(env, :degree_name)
             notify_admin(env, field: :degree_name, new_entries: all_new_entries)
           end
-          if env.curation_concern.respond_to?(:degree_grantors) && env.curation_concern.degree_grantors.present? && env.curation_concern.respond_to?(:degree_grantors_other) && env.curation_concern.degree_grantors_other.present?
-            puts "degree grantors other and notifying admin"
-            OtherOption.find_or_create_by(name: env.curation_concern.degree_grantors_other.to_s, work_id: env.curation_concern.id, property_name: :degree_grantors.to_s)
-            notify_admin(env, field: :degree_grantors, new_entries: env.curation_concern.degree_grantors_other)
-          end
+        end
+
+        if env.curation_concern.respond_to?(:degree_grantors) && env.curation_concern.degree_grantors.present? && env.curation_concern.respond_to?(:degree_grantors_other) && env.curation_concern.degree_grantors_other.present?
+          puts "degree grantors other and notifying admin"
+          OtherOption.find_or_create_by(name: env.curation_concern.degree_grantors_other.to_s, work_id: env.curation_concern.id, property_name: :degree_grantors.to_s)
+          notify_admin(env, field: :degree_grantors, new_entries: env.curation_concern.degree_grantors_other)
         end
 
         if other_affiliation_other_present? (env)
@@ -64,6 +65,14 @@ module ScholarsArchive
       def other_affiliation_options(env_user)
         service = ScholarsArchive::OtherAffiliationService.new
         env_user.admin? ? service.select_sorted_all_options : service.select_active_options
+      end
+
+      def is_valid_other_field?(env, field)
+        ScholarsArchive::FieldValidationService.is_valid_other_field?(env.curation_concern, field: field, env_user: env.user)
+      end
+
+      def is_valid_other_field_multiple? (env, field)
+        ScholarsArchive::FieldValidationService.is_valid_other_field_multiple?(env.curation_concern, field: field, env_user: env.user)
       end
 
       def valid_other_affiliation_other? (record, field: nil, collection: [])
@@ -100,13 +109,13 @@ module ScholarsArchive
 
       def update_custom_option(env)
         if degree_present? (env)
-          if env.curation_concern.degree_field_other.present?
+          if env.curation_concern.degree_field_other.present? && is_valid_other_field_multiple?(env, :degree_field)
 
             all_new_entries = persist_multiple_other_entries(env, :degree_field)
             notify_admin(env, field: :degree_field, new_entries: all_new_entries)
           end
 
-          if env.curation_concern.degree_level_other.present?
+          if env.curation_concern.degree_level_other.present? && is_valid_other_field?(env, :degree_level)
             degree_level_other_option = get_other_option(env, :degree_level)
             if degree_level_other_option.present?
               OtherOption.update(degree_level_other_option.id, name: env.curation_concern.degree_level_other.to_s)
@@ -116,7 +125,7 @@ module ScholarsArchive
             end
           end
 
-          if env.curation_concern.degree_name_other.present?
+          if env.curation_concern.degree_name_other.present? && is_valid_other_field_multiple?(env, :degree_field)
             puts "degree name other and notifying admin"
             all_new_entries = persist_multiple_other_entries(env, :degree_name)
             notify_admin(env, field: :degree_name, new_entries: all_new_entries)

--- a/app/models/default.rb
+++ b/app/models/default.rb
@@ -14,6 +14,7 @@ class Default < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  self.validates_with ScholarsArchive::Validators::OtherOptionDegreeValidator
   self.validates_with ScholarsArchive::Validators::OtherAffiliationValidator
   self.validates_with ScholarsArchive::Validators::NestedRelatedItemsValidator
 

--- a/app/services/scholars_archive/field_validation_service.rb
+++ b/app/services/scholars_archive/field_validation_service.rb
@@ -1,0 +1,140 @@
+module ScholarsArchive
+  class FieldValidationService
+    def self.degree_field_options(env_user)
+      service = ScholarsArchive::DegreeFieldService.new
+      env_user.present? && env_user.admin? ? service.select_sorted_all_options_truncated : service.select_sorted_current_options_truncated
+    end
+
+    def self.degree_level_options(env_user)
+      service = ScholarsArchive::DegreeLevelService.new
+      env_user.present? && env_user.admin? ? service.select_sorted_all_options : service.select_active_options
+    end
+
+    def self.degree_name_options(env_user)
+      service = ScholarsArchive::DegreeNameService.new
+      env_user.present? && env_user.admin? ? service.select_sorted_all_options : service.select_active_options
+    end
+
+    def self.degree_grantors_options(value, env_user)
+      service = ScholarsArchive::DegreeGrantorsService.new
+      service.select_sorted_all_options(value, env_user.present? ? env_user.admin? : false)
+    end
+
+    def self.get_collection(field, record: nil, env_user: nil)
+      if field.to_s == "degree_level"
+        degree_level_options(env_user)
+      elsif field.to_s == "degree_grantors"
+        degree_grantors_options(record.degree_grantors, env_user)
+      elsif field.to_s == "degree_name"
+        degree_name_options(env_user)
+      elsif field.to_s == "degree_field"
+        degree_field_options(env_user)
+      else
+        []
+      end
+    end
+
+    def self.validate_other_value? (record, field: nil, env_user: nil)
+      other_field = "#{field}_other".to_sym
+      other_value = record.send(other_field)
+      error_counter = 0
+      collection = get_collection(field, record: record, env_user: env_user)
+      if other_value.present?
+        if other_value_in_collection? other_value: other_value, collection: collection
+          add_error_message(record, other_field, I18n.translate(:"simple_form.actor_validation.other_value_exists", other_entry: other_value.to_s))
+          error_counter += 1
+        end
+      else
+        if record.class.ancestors.include?(::ScholarsArchive::EtdMetadata) && record.attributes[field.to_s] == 'Other'
+          add_error_message(record, other_field, I18n.t("simple_form.actor_validation.other_value_missing"))
+          error_counter += 1
+        end
+      end
+      return error_counter
+    end
+
+    def self.is_valid_other_field?(record, field: nil, env_user: nil)
+      other_field = "#{field}_other".to_sym
+      other_value = record.send(other_field)
+      error_counter = 0
+      collection = get_collection(field, record: record, env_user: env_user)
+      if other_value.present?
+        if other_value_in_collection? other_value: other_value, collection: collection
+          error_counter += 1
+        end
+      else
+        if record.class.ancestors.include?(::ScholarsArchive::EtdMetadata) && record.attributes[field.to_s] == 'Other'
+          error_counter += 1
+        end
+      end
+      (error_counter > 0) ? false : true
+    end
+
+    def self.is_valid_other_field_multiple? (record, field: nil, env_user: nil)
+      other_field = "#{field}_other".to_sym
+      other_value = record.send(other_field)
+      error_counter = 0
+      collection = get_collection(field, record: record, env_user: env_user)
+
+      if other_value.present?
+        other_value.each do |entry|
+          if other_value_in_collection? other_value: entry, collection: collection
+            error_counter += 1
+          end
+        end
+      else
+        if record.class.ancestors.include?(::ScholarsArchive::EtdMetadata) && record.attributes[field.to_s].present? && record.attributes[field.to_s].include?('Other')
+          error_counter += 1
+        end
+      end
+      (error_counter > 0) ? false : true
+    end
+
+    # This will now check if there is value passed in, since this can be used for optional fields (i.e. other_affiliation)
+    # as well as required ones with multiples allowed (i.e. degree_field)
+    def self.validate_other_value_multiple? (record, field: nil, env_user: nil)
+      other_field = "#{field}_other".to_sym
+      other_value = record.send(other_field)
+      error_counter = 0
+      collection = get_collection(field, record: record, env_user: env_user)
+
+      valid_values = []
+      if other_value.present?
+        other_value.each do |entry|
+          if other_value_in_collection? other_value: entry, collection: collection
+            err_message = I18n.translate(:"simple_form.actor_validation.other_value_exists", other_entry: entry.to_s)
+            add_error_message(record, other_field, err_message)
+            record.send(field) << [{option: "Other", err_msg: err_message, other_entry: entry.to_s}.to_json]
+            error_counter += 1
+          else
+            valid_values << entry.to_s
+          end
+        end
+      else
+        if record.class.ancestors.include?(::ScholarsArchive::EtdMetadata) && record.attributes[field.to_s].present? && record.attributes[field.to_s].include?('Other')
+          err_message = I18n.t("simple_form.actor_validation.other_value_missing")
+          add_error_message(record, other_field, err_message)
+          record.send(field) << [{option: "Other", err_msg: err_message}.to_json]
+          error_counter += 1
+        end
+      end
+
+      if error_counter > 0
+        valid_values.each do |entry|
+          record.send(field) << [{option: "Other", err_valid_val:true, other_entry: entry.to_s}.to_json]
+        end
+      end
+      return error_counter
+    end
+
+    def self.other_value_in_collection? (other_value: nil, collection: [])
+      !collection.select {|option| option.include? other_value}.empty? ? true : false
+    end
+
+    private
+
+    def self.add_error_message(record, field, error_msg)
+      record.errors[field.to_s] << error_msg
+    end
+  end
+end

--- a/lib/scholars_archive/validators/other_option_degree_validator.rb
+++ b/lib/scholars_archive/validators/other_option_degree_validator.rb
@@ -14,19 +14,26 @@ module ScholarsArchive::Validators
 
       if degree_present? (record)
         # check if degree_level_other is already in the list or is missing
-        error_counter += validate_other_value? record, field: :degree_level, collection: degree_level_options(current_user_editor(record))
+        error_counter += ScholarsArchive::FieldValidationService.validate_other_value? record,
+                                                                                       field: :degree_level,
+                                                                                       env_user: current_user_editor(record)
 
         # check if degree_field_other is already in the list or is missing
-        error_counter += validate_other_value_multiple? record, field: :degree_field, collection: degree_field_options(current_user_editor(record))
+        error_counter += ScholarsArchive::FieldValidationService.validate_other_value_multiple? record,
+                                                                                                field: :degree_field,
+                                                                                                env_user: current_user_editor(record)
 
         # check if degree_name_other is already in the list or is missing
-        error_counter += validate_other_value_multiple? record, field: :degree_name, collection: degree_name_options(current_user_editor(record))
-
+        error_counter += ScholarsArchive::FieldValidationService.validate_other_value_multiple? record,
+                                                                                                field: :degree_name,
+                                                                                                env_user: current_user_editor(record)
       end
 
       if degree_grantors_present? (record)
         # check if degree_grantors_other is already in the list or is missing
-        error_counter += validate_other_value? record, field: :degree_grantors, collection: degree_grantors_options(record.degree_grantors, current_user_editor(record))
+        error_counter += ScholarsArchive::FieldValidationService.validate_other_value? record,
+                                                                                       field: :degree_grantors,
+                                                                                       env_user: current_user_editor(record)
       end
 
       return
@@ -36,90 +43,6 @@ module ScholarsArchive::Validators
       if record.respond_to?(:current_username)
         User.find_by_username(record.current_username.to_s) if record.current_username.present?
       end
-    end
-
-    def degree_field_options(env_user)
-      service = ScholarsArchive::DegreeFieldService.new
-      env_user.present? && env_user.admin? ? service.select_sorted_all_options_truncated : service.select_sorted_current_options_truncated
-    end
-
-    def degree_level_options(env_user)
-      service = ScholarsArchive::DegreeLevelService.new
-      env_user.present? && env_user.admin? ? service.select_sorted_all_options : service.select_active_options
-    end
-
-    def degree_name_options(env_user)
-      service = ScholarsArchive::DegreeNameService.new
-      env_user.present? && env_user.admin? ? service.select_sorted_all_options : service.select_active_options
-    end
-
-    def degree_grantors_options(value, env_user)
-      service = ScholarsArchive::DegreeGrantorsService.new
-      service.select_sorted_all_options(value, env_user.present? ? env_user.admin? : false)
-    end
-
-    def validate_other_value? (record, field: nil, collection: [])
-      other_field = "#{field}_other".to_sym
-      other_value = record.send(other_field)
-      error_counter = 0
-      if other_value.present?
-        if other_value_in_collection? other_value: other_value, collection: collection
-          add_error_message(record, other_field, I18n.translate(:"simple_form.actor_validation.other_value_exists", other_entry: other_value.to_s))
-          error_counter += 1
-        end
-      else
-        if record.attributes[field.to_s] == 'Other'
-          add_error_message(record, other_field, I18n.t("simple_form.actor_validation.other_value_missing"))
-          error_counter += 1
-        end
-      end
-      return error_counter
-    end
-
-    # This will now check if there is value passed in, since this can be used for optional fields (i.e. other_affiliation)
-    # as well as required ones with multiples allowed (i.e. degree_field)
-    def validate_other_value_multiple? (record, field: nil, collection: [])
-      other_field = "#{field}_other".to_sym
-      other_value = record.send(other_field)
-      error_counter = 0
-
-      valid_values = []
-      if other_value.present?
-        other_value.each do |entry|
-          if other_value_in_collection? other_value: entry, collection: collection
-            err_message = I18n.translate(:"simple_form.actor_validation.other_value_exists", other_entry: entry.to_s)
-            add_error_message(record, other_field, err_message)
-            record.send(field) << [{option: "Other", err_msg: err_message, other_entry: entry.to_s}.to_json]
-            error_counter += 1
-          else
-            valid_values << entry.to_s
-          end
-        end
-      else
-        if record.attributes[field.to_s].present? && record.attributes[field.to_s].include?('Other')
-          err_message = I18n.t("simple_form.actor_validation.other_value_missing")
-          add_error_message(record, other_field, err_message)
-          record.send(field) << [{option: "Other", err_msg: err_message}.to_json]
-          error_counter += 1
-        end
-      end
-
-      if error_counter > 0
-        valid_values.each do |entry|
-          record.send(field) << [{option: "Other", err_valid_val:true, other_entry: entry.to_s}.to_json]
-        end
-      end
-      return error_counter
-    end
-
-    def other_value_in_collection? (other_value: nil, collection: [])
-      !collection.select {|option| option.include? other_value}.empty? ? true : false
-    end
-
-    private
-
-    def add_error_message(record, field, error_msg)
-      record.errors[field.to_s] << error_msg
     end
   end
 end

--- a/spec/views/hyrax/base/_form_instructions_spec.rb
+++ b/spec/views/hyrax/base/_form_instructions_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'spec_helper'
 
 RSpec.describe 'hyrax/base/_form.erb', type: :view do
-  let(:current_user) { User.new(email: 'test@example.com', guest: false) }
+  let(:current_user) { User.new(username: 'admin', email: 'test@example.com', guest: false) }
   let(:ability) { double }
   let(:form) do
     Hyrax::DefaultForm.new(work, ability, controller)
@@ -40,21 +40,28 @@ RSpec.describe 'hyrax/base/_form.erb', type: :view do
   let(:options_presenter) { double(select_options: []) }
 
   before do
+    allow_any_instance_of(ScholarsArchive::AcademicUnitsService).to receive(:select_sorted_all_options).and_return(academic_unit_sorted_all_options)
+    allow_any_instance_of(ScholarsArchive::AcademicUnitsService).to receive(:select_sorted_current_options).and_return(academic_unit_sorted_current_options)
+    allow_any_instance_of(ScholarsArchive::DegreeFieldService).to receive(:select_sorted_all_options).and_return(test_sorted_all_options)
+    allow_any_instance_of(ScholarsArchive::DegreeFieldService).to receive(:select_sorted_current_options_truncated).and_return(test_sorted_current_options)
+    allow_any_instance_of(ScholarsArchive::DegreeLevelService).to receive(:select_sorted_all_options).and_return([['Other', 'Other'],['Certificate','Certificate']])
+    allow_any_instance_of(ScholarsArchive::DegreeNameService).to receive(:select_sorted_all_options).and_return([['Other', 'Other'],['Master of Arts (M.A.)','Master of Arts (M.A.)']])
+    allow_any_instance_of(ScholarsArchive::DegreeGrantorsService).to receive(:select_sorted_all_options).and_return([['Other', 'Other'],['http://id.loc.gov/authorities/names/n80017721','Oregon State University']])
+    allow_any_instance_of(ScholarsArchive::OtherAffiliationService).to receive(:select_sorted_all_options).and_return([['Other', 'Other'],['http://opaquenamespace.org/ns/subject/OregonStateUniversityBioenergyMinorProgram', 'Oregon State University Bioenergy Minor Program']])
     allow(Hyrax::AdminSetOptionsPresenter).to receive(:new).and_return(options_presenter)
     stub_template('hyrax/base/_form_progress.html.erb' => 'Progress')
     stub_template('hyrax/base/_form_relationships.html.erb' => "Relationships")
     allow(work).to receive(:new_record?).and_return(true)
     allow(work).to receive(:member_ids).and_return([1, 2])
+    allow_any_instance_of(User).to receive(:admin?).and_return(true)
+    allow(work).to receive(:current_username).and_return("admin")
     allow(ability).to receive(:current_user).and_return(current_user)
     allow(curation_concern.model_name).to receive(:name).and_return('default')
     allow(controller).to receive(:current_user).and_return(current_user)
     assign(:form, form)
     allow(controller).to receive(:controller_name).and_return('batch_uploads')
     allow(controller).to receive(:action_name).and_return('new')
-    allow_any_instance_of(ScholarsArchive::AcademicUnitsService).to receive(:select_sorted_all_options).and_return(academic_unit_sorted_all_options)
-    allow_any_instance_of(ScholarsArchive::AcademicUnitsService).to receive(:select_sorted_current_options).and_return(academic_unit_sorted_current_options)
-    allow_any_instance_of(ScholarsArchive::DegreeFieldService).to receive(:select_sorted_all_options).and_return(test_sorted_all_options)
-    allow_any_instance_of(ScholarsArchive::DegreeFieldService).to receive(:select_sorted_current_options).and_return(test_sorted_current_options)
+
   end
 
   context 'batch upload off' do

--- a/spec/views/hyrax/base/_work_description.erb_spec.rb
+++ b/spec/views/hyrax/base/_work_description.erb_spec.rb
@@ -20,8 +20,26 @@ RSpec.describe 'hyrax/base/_work_description.erb', type: :view do
   let(:workflow_presenter) do
     double('workflow_presenter', badge: 'Foobar')
   end
+
+  let(:test_sorted_all_options) do
+    [
+        ["Adult Education - {1989..1990,1995,2001,2016}", "http://opaquenamespace.org/ns/osuDegreeFields/OGvwFaYi"],
+        ["Animal Breeding - 1952", "http://opaquenamespace.org/ns/osuDegreeFields/KWzvXUyz"],
+    ]
+  end
+  let(:test_sorted_current_options) do
+    [
+        ["Adult Education - {1989..1990,1995,2001,2016}", "http://opaquenamespace.org/ns/osuDegreeFields/OGvwFaYi"],
+    ]
+  end
   let(:page) { Capybara::Node::Simple.new(rendered) }
   before do
+    allow_any_instance_of(ScholarsArchive::DegreeLevelService).to receive(:select_sorted_all_options).and_return([['Other', 'Other'],['Certificate','Certificate']])
+    allow_any_instance_of(ScholarsArchive::DegreeFieldService).to receive(:select_sorted_current_options_truncated).and_return(test_sorted_current_options)
+    allow_any_instance_of(ScholarsArchive::DegreeFieldService).to receive(:select_sorted_all_options).and_return(test_sorted_all_options)
+    allow_any_instance_of(ScholarsArchive::DegreeNameService).to receive(:select_sorted_all_options).and_return([['Other', 'Other'],['Master of Arts (M.A.)','Master of Arts (M.A.)']])
+    allow_any_instance_of(ScholarsArchive::DegreeGrantorsService).to receive(:select_sorted_all_options).and_return([['Other', 'Other'],['http://id.loc.gov/authorities/names/n80017721','Oregon State University']])
+    allow_any_instance_of(ScholarsArchive::OtherAffiliationService).to receive(:select_sorted_all_options).and_return([['Other', 'Other'],['http://opaquenamespace.org/ns/subject/OregonStateUniversityBioenergyMinorProgram', 'Oregon State University Bioenergy Minor Program']])
     allow(presenter).to receive(:workflow).and_return(workflow_presenter)
     assign(:presenter, presenter)
     render 'hyrax/base/work_description.erb', presenter: presenter


### PR DESCRIPTION
fixes #1332 

Created `FieldValidationService` to handle validation for `Other` values provided for degree fields (degree_field, degree_name, degree_level, degree_grantors) so that it can be used both in the actor `add_other_field_option_actor` and the form validator `other_option_degree_validator`.

 The service also takes care of the validation logic and checks if it's an etd or non-etd (i.e. `Default`) and assigns the proper validation.

related: #1301