### PR TITLE
Feature/update batch upload object

### DIFF
--- a/app/models/batch_upload_item.rb
+++ b/app/models/batch_upload_item.rb
@@ -24,4 +24,8 @@ class BatchUploadItem < ActiveFedora::Base
   def create_or_update
     raise "This is a read only record"
   end
+
+  private
+  def set_defaults
+  end
 end


### PR DESCRIPTION
Fixes #1392

This adds the set_default piece of code to the batch upload of items. 

<img width="797" alt="screen shot 2018-05-14 at 10 24 02 am" src="https://user-images.githubusercontent.com/6424683/40013153-92f7aeb0-5761-11e8-939a-f58ecd0dc13e.png">
