### PR TITLE
Feature/display first label

### DIFF
--- a/app/indexers/default_work_indexer.rb
+++ b/app/indexers/default_work_indexer.rb
@@ -21,10 +21,9 @@ class DefaultWorkIndexer < Hyrax::WorkIndexer
         uris = Array(object.send(o[:field]))
         uris = Array(object.send(o[:field])).reject { |u| u == "Other" }
         labels = ScholarsArchive::TriplePoweredService.new.fetch_top_label(uris, parse_date: o[:has_date])
-        solr_doc[o[:field].to_s + '_label_ssim'] = [labels.first]
-        solr_doc[o[:field].to_s + '_label_tesim'] = [labels.first]
+        solr_doc[o[:field].to_s + '_label_ssim'] = labels
+        solr_doc[o[:field].to_s + '_label_tesim'] = labels
       end
-
       solr_doc['based_near_linked_ssim'] = object.based_near.each.map{ |location| location.solrize.second[:label]}
       solr_doc['based_near_linked_tesim'] = object.based_near.each.map{ |location| location.solrize.second[:label]}
       solr_doc['rights_statement_label_ssim'] = rights_statement_labels

--- a/app/indexers/default_work_indexer.rb
+++ b/app/indexers/default_work_indexer.rb
@@ -18,19 +18,11 @@ class DefaultWorkIndexer < Hyrax::WorkIndexer
       language_labels = ScholarsArchive::LanguageService.new.all_labels(object.language)
       peerreviewed_label = ScholarsArchive::PeerreviewedService.new.all_labels(object.peerreviewed)
       object.triple_powered_properties.each do |o|
-        if ScholarsArchive::FormMetadataService.multiple? object.class, o[:field]
-          uris = object.send(o[:field])
-          uris = object.send(o[:field]).reject { |u| u == "Other"}
-          labels = ScholarsArchive::TriplePoweredService.new.fetch_all_labels(uris)
-        else
-          uris = Array(object.send(o[:field]))
-          uris = Array(object.send(o[:field])).reject { |u| u == "Other" }
-          labels = ScholarsArchive::TriplePoweredService.new.fetch_top_label(uris, parse_date: o[:has_date])
-        end
+        uris = Array(object.send(o[:field]))
+        uris = Array(object.send(o[:field])).reject { |u| u == "Other" }
+        labels = ScholarsArchive::TriplePoweredService.new.fetch_top_label(uris, parse_date: o[:has_date])
         solr_doc[o[:field].to_s + '_label_ssim'] = [labels.first]
         solr_doc[o[:field].to_s + '_label_tesim'] = [labels.first]
-        solr_doc[o[:field].to_s + '_alt_label_ssim'] = labels.drop(1)
-        solr_doc[o[:field].to_s + '_alt_label_tesim'] = labels.drop(1)
       end
 
       solr_doc['based_near_linked_ssim'] = object.based_near.each.map{ |location| location.solrize.second[:label]}

--- a/app/indexers/default_work_indexer.rb
+++ b/app/indexers/default_work_indexer.rb
@@ -27,8 +27,10 @@ class DefaultWorkIndexer < Hyrax::WorkIndexer
           uris = Array(object.send(o[:field])).reject { |u| u == "Other" }
           labels = ScholarsArchive::TriplePoweredService.new.fetch_top_label(uris, parse_date: o[:has_date])
         end
-        solr_doc[o[:field].to_s + '_label_ssim'] = labels
-        solr_doc[o[:field].to_s + '_label_tesim'] = labels
+        solr_doc[o[:field].to_s + '_label_ssim'] = [labels.first]
+        solr_doc[o[:field].to_s + '_label_tesim'] = [labels.first]
+        solr_doc[o[:field].to_s + '_alt_label_ssim'] = labels.drop(1)
+        solr_doc[o[:field].to_s + '_alt_label_tesim'] = labels.drop(1)
       end
 
       solr_doc['based_near_linked_ssim'] = object.based_near.each.map{ |location| location.solrize.second[:label]}

--- a/app/indexers/default_work_indexer.rb
+++ b/app/indexers/default_work_indexer.rb
@@ -18,8 +18,8 @@ class DefaultWorkIndexer < Hyrax::WorkIndexer
       language_labels = ScholarsArchive::LanguageService.new.all_labels(object.language)
       peerreviewed_label = ScholarsArchive::PeerreviewedService.new.all_labels(object.peerreviewed)
       object.triple_powered_properties.each do |o|
-        uris = Array(object.send(o[:field]))
-        uris = Array(object.send(o[:field])).reject { |u| u == "Other" }
+        uris = object.send(o[:field])
+        uris = object.send(o[:field]).reject { |u| u == "Other" }
         labels = ScholarsArchive::TriplePoweredService.new.fetch_top_label(uris, parse_date: o[:has_date])
         solr_doc[o[:field].to_s + '_label_ssim'] = labels
         solr_doc[o[:field].to_s + '_label_tesim'] = labels

--- a/app/indexers/default_work_indexer.rb
+++ b/app/indexers/default_work_indexer.rb
@@ -18,8 +18,8 @@ class DefaultWorkIndexer < Hyrax::WorkIndexer
       language_labels = ScholarsArchive::LanguageService.new.all_labels(object.language)
       peerreviewed_label = ScholarsArchive::PeerreviewedService.new.all_labels(object.peerreviewed)
       object.triple_powered_properties.each do |o|
-        uris = object.send(o[:field])
-        uris = object.send(o[:field]).reject { |u| u == "Other" }
+        uris = Array(object.send(o[:field]))
+        uris = Array(object.send(o[:field])).reject { |u| u == "Other" }
         labels = ScholarsArchive::TriplePoweredService.new.fetch_top_label(uris, parse_date: o[:has_date])
         solr_doc[o[:field].to_s + '_label_ssim'] = labels
         solr_doc[o[:field].to_s + '_label_tesim'] = labels


### PR DESCRIPTION
Fixes #1288 

This Indexes the first label as the primary label and all others as the alt labels. If only one label is returned, it will index an empty array in the alt label field.