### PR TITLE
override blacklights facet partial to prevent the double rendering of facet_pagination

### DIFF
--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -1,0 +1,19 @@
+<div class="modal-header">
+  <button type="button" class="ajax-modal-close close" data-dismiss="modal" aria-hidden="true">×</button>
+
+  <h3 class="modal-title"><%= facet_field_label(@facet.key) %></h3>
+  <%= render partial: 'facet_index_navigation' if @facet.index_range && @display_facet.index? %>
+
+</div>
+<div class="modal-body">
+  <div class="facet_extended_list">
+  <%= render_facet_limit(@display_facet, layout: false) %>
+  </div>
+</div>
+
+<div class="modal-footer">
+
+  <div class="facet_pagination bottom">
+    <%= render :partial=>'facet_pagination' %>
+  </div>
+</div>


### PR DESCRIPTION
Facet pagination is a very slow partial, SA is not displaying the "header" pagination so it shouldn't be rendered (and cause the _facet_pagination partial to slowly render again)