### PR TITLE
For properties with multiple, get top label of each URI.

### DIFF
--- a/app/indexers/default_work_indexer.rb
+++ b/app/indexers/default_work_indexer.rb
@@ -18,9 +18,20 @@ class DefaultWorkIndexer < Hyrax::WorkIndexer
       language_labels = ScholarsArchive::LanguageService.new.all_labels(object.language)
       peerreviewed_label = ScholarsArchive::PeerreviewedService.new.all_labels(object.peerreviewed)
       object.triple_powered_properties.each do |o|
-        uris = Array(object.send(o[:field]))
-        uris = Array(object.send(o[:field])).reject { |u| u == "Other" }
-        labels = ScholarsArchive::TriplePoweredService.new.fetch_top_label(uris, parse_date: o[:has_date])
+        labels = []
+        if ScholarsArchive::FormMetadataService.multiple? object.class, o[:field]
+          uris = object.send(o[:field])
+          uris = object.send(o[:field]).reject { |u| u == "Other"}
+
+          # if multiple URIs, need to get top label for each one
+          uris.each do |uri|
+            labels << ScholarsArchive::TriplePoweredService.new.fetch_top_label(uri.lines.to_a, parse_date: o[:has_date])
+          end
+        else
+          uris = Array(object.send(o[:field]))
+          uris = Array(object.send(o[:field])).reject { |u| u == "Other" }
+          labels = ScholarsArchive::TriplePoweredService.new.fetch_top_label(uris, parse_date: o[:has_date])
+        end
         solr_doc[o[:field].to_s + '_label_ssim'] = labels
         solr_doc[o[:field].to_s + '_label_tesim'] = labels
       end


### PR DESCRIPTION
Fixes #1467 

Adds back in the multiple? check and iterates over values to call top_label on each one.