### PR TITLE
modified template to remove extraneous info

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,8 @@
 ### Descriptive summary
 
-Include what version of Hyrax relates to this issue (7.x, 6.x, HEAD, etc.) if appropriate, and any relevant tracebacks if you're reporting a bug.
-
-### Rationale
-
 Provide the rationale or user story that describes "why" this issue should be addressed. Especially if this is a new feature or significant change to the existing implementation.
+
+Include what version of Hyrax relates to this issue (7.x, 6.x, HEAD, etc.) if appropriate, and any relevant tracebacks if you're reporting a bug.
 
 ### Expected behavior
 


### PR DESCRIPTION
removed #rationale section because i've always hated that part as it seems duplicative of the Descriptive Summary section