### PR TITLE
added NestedOrderedCreator model

### DIFF
--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -205,7 +205,7 @@ module ScholarsArchive
         index.as :stored_searchable
       end
 
-      property :nested_ordered_creator, predicate: ::RDF::Vocab::DC11.creator, :class_name => NestedOrderedCreator do |index|
+      property :nested_ordered_creator, predicate: ::RDF::URI("http://id.loc.gov/vocabulary/relators/aut"), :class_name => NestedOrderedCreator do |index|
         index.as :stored_searchable, :facetable
       end
 

--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -205,6 +205,10 @@ module ScholarsArchive
         index.as :stored_searchable
       end
 
+      property :nested_ordered_creator, predicate: ::RDF::Vocab::DC11.creator, :class_name => NestedOrderedCreator do |index|
+        index.as :stored_searchable, :facetable
+      end
+
       property :other_affiliation, predicate: ::RDF::URI("http://vivoweb.org/ontology/core#Department") do |index|
         index.as :stored_searchable, :facetable
       end
@@ -268,6 +272,7 @@ module ScholarsArchive
       accepts_nested_attributes_for :based_near, :allow_destroy => true, :reject_if => proc { |a| a[:id].blank? }
       accepts_nested_attributes_for :nested_geo, :allow_destroy => true, :reject_if => :all_blank
       accepts_nested_attributes_for :nested_related_items, :allow_destroy => true, :reject_if => :all_blank
+      accepts_nested_attributes_for :nested_ordered_creator, :allow_destroy => true, :reject_if => :all_blank
     end
   end
 end

--- a/app/models/nested_ordered_creator.rb
+++ b/app/models/nested_ordered_creator.rb
@@ -1,0 +1,31 @@
+class NestedOrderedCreator < ActiveTriples::Resource
+  # Usage notes and expectations can be found in the Metadata Application Profile:
+  #   https://docs.google.com/spreadsheets/d/1koKjV7bjn7v4r5a3gsowEimljHiAwbwuOgjHe7FEtuw/edit?usp=sharing
+
+  property :index, predicate: ::RDF::Vocab::DC.identifier
+  property :creator, predicate: ::RDF::Vocab::DC.creator
+
+  attr_accessor :destroy_item # true/false
+  attr_accessor :validation_msg # string
+
+  def initialize(uri=RDF::Node.new, parent=nil)
+    if uri.try(:node?)
+      uri = RDF::URI("#nested_ordered_creator#{uri.to_s.gsub('_:', '')}")
+    elsif uri.start_with?("#")
+      uri = RDF::URI(uri)
+    end
+    super
+  end
+
+  def final_parent
+    parent
+  end
+
+  def new_record?
+    id.start_with?("#")
+  end
+
+  def _destroy
+    false
+  end
+end

--- a/spec/models/default_spec.rb
+++ b/spec/models/default_spec.rb
@@ -228,6 +228,74 @@ RSpec.describe Default do
     expect(g.nested_geo.length).to eq 2
     expect(g.nested_geo.map{|x| x.label.first}).to contain_exactly("1","2")
   end
+
+  describe "#nested_ordered_creator_attributes" do
+    let(:attributes) do
+      [{
+           :index => "0",
+           :creator => "CreatorA"
+       }]
+    end
+    it "should be able to delete items" do
+      g = described_class.new(title: ['test'])
+      g.nested_ordered_creator_attributes = attributes
+      g.nested_ordered_creator_attributes = [
+          {
+              :id => g.nested_ordered_creator.first.id,
+              :_destroy => true
+          },
+          {
+              :creator => "CreatorB"
+          }
+      ]
+      expect(g.nested_ordered_creator.length).to eq 1
+      expect(g.nested_ordered_creator.first.creator).to eq ["CreatorB"]
+    end
+    it "should work on already persisted items" do
+      g = described_class.new(title: ['test'])
+      g.nested_ordered_creator_attributes = attributes
+      expect(g.nested_ordered_creator.first.creator).to eq ["CreatorA"]
+    end
+    it "should be able to edit" do
+      g = described_class.new(title: ['test'])
+      g.nested_ordered_creator_attributes = attributes
+      expect(g.nested_ordered_creator.length).to eq 1
+      expect(g.nested_ordered_creator.first.creator).to eq ["CreatorA"]
+
+      g.nested_ordered_creator.first.creator = ["CreatorB"]
+      g.nested_ordered_creator.first.persist!
+      expect(g.nested_ordered_creator.length).to eq 1
+      expect(g.nested_ordered_creator.first.creator).to eq ["CreatorB"]
+    end
+    it "should not create blank ones" do
+      g = described_class.new(title: ['test'], keyword: ['test'])
+      g.nested_ordered_creator_attributes = [
+          {
+              :index => "",
+              :creator => "",
+          }
+      ]
+      expect(g.nested_ordered_creator.length).to eq 0
+    end
+  end
+
+  it "should be able to create multiple nested ordered creators" do
+    g = described_class.new(title: ['test'])
+    g.nested_ordered_creator_attributes = [
+        {
+          "index" => "0",
+          "creator" => "Creator1"
+        },
+        {
+          "index" => "1",
+          "creator" => "Creator2"
+        }
+    ]
+    expect(g.nested_ordered_creator.length).to eq 2
+    expect(g.nested_ordered_creator.map{|x| x.index.first}).to contain_exactly("0","1")
+    expect(g.nested_ordered_creator.map{|x| x.creator.first}).to contain_exactly("Creator1","Creator2")
+  end
+
   describe "#attributes=" do
     it "accepts nested attributes" do
       g = described_class.new(title: ['test'], keyword: ['test'])

--- a/spec/models/nested_ordered_creator_spec.rb
+++ b/spec/models/nested_ordered_creator_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'rails_helper'
+
+RSpec.describe NestedOrderedCreator do
+  subject { NestedOrderedCreator.new(uri, parent) }
+
+  let(:uri) { RDF::Node.new }
+  let(:parent) { Default::GeneratedResourceSchema.new }
+
+  describe "instantiation" do
+    context "with a string hash uri" do
+      let(:uri) { "#bla_46" }
+      it "should make it a URI" do
+        expect(subject.rdf_subject).to eq RDF::URI("#bla_46")
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes #1544 

usage:

```
> d = Default.new(title:["test"],nested_ordered_creator_attributes:[{index:"0", creator:"Greg Luis"}]).save
> d.nested_ordered_creator.first.id
=> "http://fcrepo:8080/rest/dev/vx/02/1f/08/vx021f082#nested_ordered_creatorg47002074968760"
> d.nested_ordered_creator.first.index
=> ["0"]
> d.nested_ordered_creator.first.creator
=> ["Greg Luis"]
```