### PR TITLE
Reduce size of Add User lookup field.

### DIFF
--- a/app/assets/stylesheets/osu.scss
+++ b/app/assets/stylesheets/osu.scss
@@ -210,6 +210,10 @@ table[data-behavior="child-relationships"] > tbody > tr > td {
   margin-top: 5px !important;
 }
 
+#user-participants-form .select2-container {
+  width: 40% !important;
+}
+
 div .modal-dialog {
   width: 65%;
 }


### PR DESCRIPTION
Fixes #1522 

40% width is pretty arbitrary, but large enough to handle longer email addresses in the box but not too big when screen size is smaller.
Should target both User Collections (Sharing) and Admin Sets (Participants).

![image](https://user-images.githubusercontent.com/2293544/43615238-9126d540-966b-11e8-9511-f4715fac259d.png)
