### PR TITLE
Expand more info tooltip to include links starting with http

### DIFF
--- a/app/assets/javascripts/tooltips.js
+++ b/app/assets/javascripts/tooltips.js
@@ -3,11 +3,13 @@ $(document).on('ready turbolinks:load', function() {
     placement: 'top',
     title: 'Search for this term in SA@OSU'
   };
-
-  $('.metadata > .table a').not('.btn').tooltip(search_options);
-  $('li.attribute a').not('.btn').tooltip(search_options);
-  $('li.attribute a.btn').tooltip({
+  var more_information = {
     placement: 'top',
     title: 'More information about this item'
-  });
+  };
+
+  $('.metadata > .table a').not('.btn').tooltip(search_options);
+  $('li.attribute a').not('.btn').not('[href^="http"]').tooltip(search_options);
+  $('li.attribute a.btn').tooltip(more_information);
+  $('li.attribute a[href^="http"]').tooltip(more_information);
 });


### PR DESCRIPTION
Expand more info tooltip to look for links starting with http

Could tweak further to better disambiguate between internal (other related items) or external links and provide different messages.

![image](https://user-images.githubusercontent.com/2293544/43615168-4265c65a-966b-11e8-9ffd-773b6f7bde23.png)
