### PR TITLE
updated ordered creator model to reject empty items

### DIFF
--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -272,7 +272,8 @@ module ScholarsArchive
       accepts_nested_attributes_for :based_near, :allow_destroy => true, :reject_if => proc { |a| a[:id].blank? }
       accepts_nested_attributes_for :nested_geo, :allow_destroy => true, :reject_if => :all_blank
       accepts_nested_attributes_for :nested_related_items, :allow_destroy => true, :reject_if => :all_blank
-      accepts_nested_attributes_for :nested_ordered_creator, :allow_destroy => true, :reject_if => :all_blank
+      # reject if all attributes all blank OR if either index or creator is blank
+      accepts_nested_attributes_for :nested_ordered_creator, :allow_destroy => true, :reject_if => proc { |attributes| attributes[:index].blank? || attributes[:creator].blank? || attributes.all? { |key, value| key == "_destroy" || value.blank? } }
     end
   end
 end

--- a/spec/models/default_spec.rb
+++ b/spec/models/default_spec.rb
@@ -245,11 +245,40 @@ RSpec.describe Default do
               :_destroy => true
           },
           {
+              :index => "1",
               :creator => "CreatorB"
           }
       ]
       expect(g.nested_ordered_creator.length).to eq 1
       expect(g.nested_ordered_creator.first.creator).to eq ["CreatorB"]
+    end
+    it "should not persist items when all are blank" do
+      g = described_class.new(title: ['test1'])
+      g.nested_ordered_creator_attributes = [
+          {
+              :index => "",
+              :creator => ""
+          },
+          {
+              :index => "",
+              :creator => ""
+          }
+      ]
+      expect(g.nested_ordered_creator.length).to eq 0
+    end
+    it "should not persist items when either one of the attributes are blank" do
+      g = described_class.new(title: ['test1'])
+      g.nested_ordered_creator_attributes = [
+          {
+              :index => "",
+              :creator => "CreatorA"
+          },
+          {
+              :index => "1",
+              :creator => ""
+          }
+      ]
+      expect(g.nested_ordered_creator.length).to eq 0
     end
     it "should work on already persisted items" do
       g = described_class.new(title: ['test'])


### PR DESCRIPTION
fixes #1564 

This will allow us to reject partially empty items (i.e. items with an index but without a creator and vice versa).

It should still reject the items when all of them are empty (excluding items where the destroy flag is turned on).