### PR TITLE
added support to legacy model methods for new fields

### DIFF
--- a/app/assets/javascripts/ordered_creator.js
+++ b/app/assets/javascripts/ordered_creator.js
@@ -33,7 +33,7 @@ function reindexNestedOrderedField(mutationsList) {
                      '.nested-ordered-abstract .index', 
                      '.nested-ordered-contributor .index', 
                      '.nested-ordered-additional-information .index', 
-                     '.nested-ordered-related-item .index']
+                     '.nested-ordered-related-items .index']
 
   for (element in nested_fields) {
     selectors = $(nested_fields[element]);

--- a/app/models/concerns/scholars_archive/has_nested_ordered_properties.rb
+++ b/app/models/concerns/scholars_archive/has_nested_ordered_properties.rb
@@ -12,6 +12,14 @@ module ScholarsArchive
         ordered_creators.present? ? ordered_creators : super
       end
 
+      def abstract
+        ordered_abstracts.present? ? ordered_abstracts : super
+      end
+
+      def contributor
+        ordered_contributors.present? ? ordered_contributors : super
+      end
+
       # Returns an array of only titles given an array of values that also
       # include indexes in the form [[title, index], ...].
       #
@@ -27,6 +35,14 @@ module ScholarsArchive
         sort_creators_by_index.map{ |creators| creators.first }
       end
 
+      def ordered_abstracts
+        sort_abstracts_by_index.map{ |abstracts| abstracts.first }
+      end
+
+      def ordered_contributors
+        sort_contributors_by_index.map{ |contributors| contributors.first }
+      end
+
       # Returns a sorted array (by index value) of nested titles given an array with two
       # values per element in the form [[title, index],...].
       #
@@ -40,6 +56,14 @@ module ScholarsArchive
 
       def sort_creators_by_index
         validate_creators.sort_by{ |creators| creators.second }
+      end
+
+      def sort_abstracts_by_index
+        validate_abstracts.sort_by{ |abstracts| abstracts.second }
+      end
+
+      def sort_contributors_by_index
+        validate_contributors.sort_by{ |contributors| contributors.second }
       end
 
       # Returns an array of items in the form [[title, index], ...] given an
@@ -59,6 +83,18 @@ module ScholarsArchive
       def validate_creators
         nested_ordered_creator.select { |i| i.creator.present? && i.index.present? }
           .map{|i| (i.instance_of? NestedOrderedCreator) ? [i.creator.first, i.index.first] : [i] }
+          .select(&:present?)
+      end
+
+      def validate_abstracts
+        nested_ordered_abstract.select { |i| i.abstract.present? && i.index.present? }
+          .map{|i| (i.instance_of? NestedOrderedAbstract) ? [i.abstract.first, i.index.first] : [i] }
+          .select(&:present?)
+      end
+
+      def validate_contributors
+        nested_ordered_contributor.select { |i| i.contributor.present? && i.index.present? }
+          .map{|i| (i.instance_of? NestedOrderedContributor) ? [i.contributor.first, i.index.first] : [i] }
           .select(&:present?)
       end
     end

--- a/app/models/concerns/scholars_archive/has_nested_ordered_properties.rb
+++ b/app/models/concerns/scholars_archive/has_nested_ordered_properties.rb
@@ -20,6 +20,10 @@ module ScholarsArchive
         ordered_contributors.present? ? ordered_contributors : super
       end
 
+      def additional_information
+        ordered_info.present? ? ordered_info : super
+      end
+
       # Returns an array of only titles given an array of values that also
       # include indexes in the form [[title, index], ...].
       #
@@ -43,6 +47,10 @@ module ScholarsArchive
         sort_contributors_by_index.map{ |contributors| contributors.first }
       end
 
+      def ordered_info
+        sort_info_by_index.map{ |info| info.first }
+      end
+
       # Returns a sorted array (by index value) of nested titles given an array with two
       # values per element in the form [[title, index],...].
       #
@@ -64,6 +72,10 @@ module ScholarsArchive
 
       def sort_contributors_by_index
         validate_contributors.sort_by{ |contributors| contributors.second }
+      end
+
+      def sort_info_by_index
+        validate_info.sort_by{ |info| info.second }
       end
 
       # Returns an array of items in the form [[title, index], ...] given an
@@ -95,6 +107,12 @@ module ScholarsArchive
       def validate_contributors
         nested_ordered_contributor.select { |i| i.contributor.present? && i.index.present? }
           .map{|i| (i.instance_of? NestedOrderedContributor) ? [i.contributor.first, i.index.first] : [i] }
+          .select(&:present?)
+      end
+
+      def validate_info
+        nested_ordered_additional_information.select { |i| i.additional_information.present? && i.index.present? }
+          .map{|i| (i.instance_of? NestedOrderedAdditionalInformation) ? [i.additional_information.first, i.index.first] : [i] }
           .select(&:present?)
       end
     end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -95,6 +95,10 @@ class SolrDocument
      nested_ordered_creator_label.present? ? nested_ordered_creator_label : self[Solrizer.solr_name('creator', :stored_searchable)]
   end
 
+  def abstract
+     nested_ordered_abstract_label.present? ? nested_ordered_abstract_label : self[Solrizer.solr_name('abstract', :stored_searchable)]
+  end
+
   def nested_ordered_abstract_label
     ScholarsArchive::OrderedParserService.parse(self[Solrizer.solr_name('nested_ordered_abstract_label', :symbol)])
   end

--- a/spec/models/default_spec.rb
+++ b/spec/models/default_spec.rb
@@ -460,6 +460,179 @@ RSpec.describe Default do
     expect(g.nested_ordered_title.map{|x| x.title.first}).to contain_exactly("Title1","Title2")
   end
 
+  describe "#nested_ordered_contributor_attributes" do
+    let(:attributes) do
+      [{
+        :index => "0",
+        :contributor => "ContributorA"
+      }]
+    end
+
+    it "should be able to delete items" do
+      g = described_class.new()
+      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      g.nested_ordered_contributor_attributes = attributes
+      g.nested_ordered_contributor_attributes = [
+        {
+          :id => g.nested_ordered_contributor.first.id,
+          :_destroy => true
+        },
+        {
+          :index => "1",
+          :contributor => "ContributorB"
+        }
+      ]
+      expect(g.nested_ordered_contributor.length).to eq 1
+      expect(g.nested_ordered_contributor.first.contributor).to eq ["ContributorB"]
+    end
+    it "should not persist items when all are blank" do
+      g = described_class.new()
+      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      g.nested_ordered_contributor_attributes = [
+        {
+          :index => "",
+          :contributor => ""
+        },
+        {
+          :index => "",
+          :contributor => ""
+        }
+      ]
+      expect(g.nested_ordered_contributor.length).to eq 0
+    end
+    it "should not persist items when either one of the attributes are blank" do
+      g = described_class.new()
+      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      g.nested_ordered_contributor_attributes = [
+        {
+          :index => "",
+          :contributor => "ContributorA"
+        },
+        {
+          :index => "1",
+          :contributor => ""
+        }
+      ]
+      expect(g.nested_ordered_contributor.length).to eq 0
+    end
+    it "should work on already persisted items" do
+      g = described_class.new()
+      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      g.nested_ordered_contributor_attributes = attributes
+      expect(g.nested_ordered_contributor.first.contributor).to eq ["ContributorA"]
+    end
+    it "should be able to edit" do
+      g = described_class.new()
+      g.nested_ordered_contributor_attributes = attributes
+      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      expect(g.nested_ordered_contributor.length).to eq 1
+      expect(g.nested_ordered_contributor.first.contributor).to eq ["ContributorA"]
+
+      g.nested_ordered_contributor.first.contributor = ["ContributorB"]
+      g.nested_ordered_contributor.first.persist!
+      expect(g.nested_ordered_contributor.length).to eq 1
+      expect(g.nested_ordered_contributor.first.contributor).to eq ["ContributorB"]
+    end
+    it "should not create blank ones" do
+      g = described_class.new(keyword: ['test'])
+      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      g.nested_ordered_contributor_attributes = [
+        {
+          :index => "",
+          :contributor => "",
+        }
+      ]
+      expect(g.nested_ordered_contributor.length).to eq 0
+    end
+  end
+
+  describe "#nested_ordered_abstract_attributes" do
+    let(:attributes) do
+      [{
+        :index => "0",
+        :abstract => "AbstractA"
+      }]
+    end
+
+    it "should be able to delete items" do
+      g = described_class.new()
+      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      g.nested_ordered_abstract_attributes = attributes
+      g.nested_ordered_abstract_attributes = [
+        {
+          :id => g.nested_ordered_abstract.first.id,
+          :_destroy => true
+        },
+        {
+          :index => "1",
+          :abstract => "AbstractB"
+        }
+      ]
+      expect(g.nested_ordered_abstract.length).to eq 1
+      expect(g.nested_ordered_abstract.first.abstract).to eq ["AbstractB"]
+    end
+    it "should not persist items when all are blank" do
+      g = described_class.new()
+      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      g.nested_ordered_abstract_attributes = [
+        {
+          :index => "",
+          :abstract => ""
+        },
+        {
+          :index => "",
+          :abstract => ""
+        }
+      ]
+      expect(g.nested_ordered_abstract.length).to eq 0
+    end
+    it "should not persist items when either one of the attributes are blank" do
+      g = described_class.new()
+      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      g.nested_ordered_abstract_attributes = [
+        {
+          :index => "",
+          :abstract => "AbstractA"
+        },
+        {
+          :index => "1",
+          :abstract => ""
+        }
+      ]
+      expect(g.nested_ordered_abstract.length).to eq 0
+    end
+    it "should work on already persisted items" do
+      g = described_class.new()
+      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      g.nested_ordered_abstract_attributes = attributes
+      expect(g.nested_ordered_abstract.first.abstract).to eq ["AbstractA"]
+    end
+    it "should be able to edit" do
+      g = described_class.new()
+      g.nested_ordered_abstract_attributes = attributes
+      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      expect(g.nested_ordered_abstract.length).to eq 1
+      expect(g.nested_ordered_abstract.first.abstract).to eq ["AbstractA"]
+
+      g.nested_ordered_abstract.first.abstract = ["AbstractB"]
+      g.nested_ordered_abstract.first.persist!
+      expect(g.nested_ordered_abstract.length).to eq 1
+      expect(g.nested_ordered_abstract.first.abstract).to eq ["AbstractB"]
+    end
+    it "should not create blank ones" do
+      g = described_class.new(keyword: ['test'])
+      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      g.nested_ordered_abstract_attributes = [
+        {
+          :index => "",
+          :abstract => "",
+        }
+      ]
+      expect(g.nested_ordered_abstract.length).to eq 0
+    end
+  end
+
+
   describe "#attributes=" do
     it "accepts nested attributes" do
       g = described_class.new(keyword: ['test'])


### PR DESCRIPTION
- Added support to legacy methods for `abstract`, and `contributor` on work models
- Fixed spelling issue with nested related items

- [x] Added support for `additional_information` method
- [x] Add specs to check these methods on OAI: `abstract` is used for `Description`, `contributor` is used for `Other contributor`, and `related_items` is used for `Relation` in OAI.