### PR TITLE
Fix/server error

### DIFF
--- a/app/indexers/default_work_indexer.rb
+++ b/app/indexers/default_work_indexer.rb
@@ -47,7 +47,11 @@ class DefaultWorkIndexer < Hyrax::WorkIndexer
       solr_doc['peerreviewed_label_ssim'] = peerreviewed_label
       solr_doc['peerreviewed_label_tesim'] = peerreviewed_label
       solr_doc['replaces_ssim'] = object.replaces
-      solr_doc['title_ssi'] = object.nested_ordered_title.first.title.first
+      if object.nested_ordered_title.first.present?
+        solr_doc['title_ssi'] = object.nested_ordered_title.first.title.first
+      else
+        solr_doc['title_ssi'] = object.title.first
+      end
     end
   end
 end

--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -27,7 +27,11 @@ module ScholarsArchive
         index.as :stored_searchable, :facetable
       end
 
-      property :nested_ordered_additional_information, predicate: ::RDF::Vocab::DC.description, :class_name => NestedOrderedAdditionalInformation do |index|
+      property :nested_ordered_additional_information, predicate: ::RDF::URI("http://id.loc.gov/authorities/subjects/sh2002004491"), :class_name => NestedOrderedAdditionalInformation do |index|
+        index.as :stored_searchable
+      end
+
+      property :additional_information, predicate: ::RDF::Vocab::DC.description do |index|
         index.as :stored_searchable
       end
 
@@ -56,7 +60,7 @@ module ScholarsArchive
         index.as :stored_searchable, :facetable
       end
 
-      property :nested_ordered_contributor, predicate: ::RDF::Vocab::DC11.contributor, :class_name => NestedOrderedContributor do |index|
+      property :nested_ordered_contributor, predicate: ::RDF::URI.new("http://id.loc.gov/vocabulary/relators/ctb"), :class_name => NestedOrderedContributor do |index|
         index.as :stored_searchable, :facetable
       end
 
@@ -214,11 +218,11 @@ module ScholarsArchive
         index.as :stored_searchable
       end
 
-      property :nested_ordered_creator, predicate: ::RDF::Vocab::DC11.creator, :class_name => NestedOrderedCreator do |index|
+      property :nested_ordered_creator, predicate: ::RDF::Vocab::DC.creator, :class_name => NestedOrderedCreator do |index|
         index.as :stored_searchable, :facetable
       end
 
-      property :nested_ordered_title, predicate: ::RDF::Vocab::DC11.title, :class_name => NestedOrderedTitle do |index|
+      property :nested_ordered_title, predicate: ::RDF::URI("http://id.loc.gov/authorities/subjects/sh85135655"), :class_name => NestedOrderedTitle do |index|
         index.as :stored_searchable, :facetable
       end
 

--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -222,7 +222,7 @@ module ScholarsArchive
         index.as :stored_searchable, :facetable
       end
 
-      property :nested_ordered_title, predicate: ::RDF::URI("http://id.loc.gov/authorities/subjects/sh85135655"), :class_name => NestedOrderedTitle do |index|
+      property :nested_ordered_title, predicate: ::RDF::Vocab::DC11.title, :class_name => NestedOrderedTitle do |index|
         index.as :stored_searchable, :facetable
       end
 

--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -11,7 +11,7 @@ module ScholarsArchive
       def set_default_visibility
         self.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC if new_record?
       end
-      
+
       # Provide each model a hook to set property defaults
       after_initialize :set_defaults, unless: :persisted?
 
@@ -27,7 +27,7 @@ module ScholarsArchive
         index.as :stored_searchable, :facetable
       end
 
-      property :nested_ordered_additional_information, predicate: ::RDF::URI("http://id.loc.gov/authorities/subjects/sh2002004491"), :class_name => NestedOrderedAdditionalInformation do |index|
+      property :nested_ordered_additional_information, predicate: ::RDF::Vocab::DC.description, :class_name => NestedOrderedAdditionalInformation do |index|
         index.as :stored_searchable
       end
 
@@ -60,7 +60,7 @@ module ScholarsArchive
         index.as :stored_searchable, :facetable
       end
 
-      property :nested_ordered_contributor, predicate: ::RDF::URI.new("http://id.loc.gov/vocabulary/relators/ctb"), :class_name => NestedOrderedContributor do |index|
+      property :nested_ordered_contributor, predicate: ::RDF::Vocab::DC11.contributor, :class_name => NestedOrderedContributor do |index|
         index.as :stored_searchable, :facetable
       end
 
@@ -218,7 +218,7 @@ module ScholarsArchive
         index.as :stored_searchable
       end
 
-      property :nested_ordered_creator, predicate: ::RDF::Vocab::DC.creator, :class_name => NestedOrderedCreator do |index|
+      property :nested_ordered_creator, predicate: ::RDF::Vocab::DC11.creator, :class_name => NestedOrderedCreator do |index|
         index.as :stored_searchable, :facetable
       end
 

--- a/app/models/concerns/scholars_archive/has_solr_labels.rb
+++ b/app/models/concerns/scholars_archive/has_solr_labels.rb
@@ -40,7 +40,12 @@ module ScholarsArchive
             doc[ActiveFedora.index_field_mapper.solr_name(label_set[:label], :symbol)] = label_set[:data]
             doc[ActiveFedora.index_field_mapper.solr_name(label_set[:label], :stored_searchable)] = label_set[:data] 
           end
+          if ordered_title_labels.present?
+            ordered_titles = nested_ordered_title.select { |i| (i.instance_of? NestedOrderedTitle) ? (i.title.present? && i.index.present?) : i.present? }.map{|i| (i.instance_of? NestedOrderedTitle) ? [i.title.first, i.index.first] : [i] }.select(&:present?).sort_by{ |titles| titles.second }.map{ |titles| titles.first }
 
+            doc[ActiveFedora.index_field_mapper.solr_name("title", :stored_searchable)] = ordered_titles
+          end
+          
           doc[ActiveFedora.index_field_mapper.solr_name("rights_statement", :facetable)] = rights_statement.first
           doc[ActiveFedora.index_field_mapper.solr_name("license", :facetable)] = license.first
         end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -80,39 +80,35 @@ class SolrDocument
   end
 
   def nested_ordered_creator_label
-    ScholarsArchive::OrderedParserService.parse(self[Solrizer.solr_name('nested_ordered_creator_label', :symbol)])
-  end 
+    ScholarsArchive::OrderedParserService.parse(self[Solrizer.solr_name('nested_ordered_creator_label', :symbol)]) || []
+  end
 
   def nested_ordered_title_label
-    ScholarsArchive::OrderedParserService.parse(self[Solrizer.solr_name('nested_ordered_title_label', :symbol)])
+    ScholarsArchive::OrderedParserService.parse(self[Solrizer.solr_name('nested_ordered_title_label', :symbol)]) || []
   end
 
   def title
-     nested_ordered_title_label.present? ? nested_ordered_title_label : self[Solrizer.solr_name('title', :stored_searchable)]
+     nested_ordered_title_label.present? ? nested_ordered_title_label : self[Solrizer.solr_name('title', :stored_searchable)] || []
   end
 
   def creator
-     nested_ordered_creator_label.present? ? nested_ordered_creator_label : self[Solrizer.solr_name('creator', :stored_searchable)]
-  end
-
-  def abstract
-     nested_ordered_abstract_label.present? ? nested_ordered_abstract_label : self[Solrizer.solr_name('abstract', :stored_searchable)]
+     nested_ordered_creator_label.present? ? nested_ordered_creator_label : self[Solrizer.solr_name('creator', :stored_searchable)] || []
   end
 
   def additional_information
-     nested_ordered_additional_information_label.present? ? nested_ordered_additional_information_label : self[Solrizer.solr_name('additional_information', :stored_searchable)]
+     nested_ordered_additional_information_label.present? ? nested_ordered_additional_information_label : self[Solrizer.solr_name('additional_information', :stored_searchable)] || []
   end
 
   def nested_ordered_abstract_label
-    ScholarsArchive::OrderedParserService.parse(self[Solrizer.solr_name('nested_ordered_abstract_label', :symbol)])
+    ScholarsArchive::OrderedParserService.parse(self[Solrizer.solr_name('nested_ordered_abstract_label', :symbol)]) || []
   end
 
   def nested_ordered_contributor_label
-    ScholarsArchive::OrderedParserService.parse(self[Solrizer.solr_name('nested_ordered_contributor_label', :symbol)])
+    ScholarsArchive::OrderedParserService.parse(self[Solrizer.solr_name('nested_ordered_contributor_label', :symbol)]) || []
   end
 
   def nested_ordered_additional_information_label
-    ScholarsArchive::OrderedParserService.parse(self[Solrizer.solr_name('nested_ordered_additional_information_label', :symbol)])
+    ScholarsArchive::OrderedParserService.parse(self[Solrizer.solr_name('nested_ordered_additional_information_label', :symbol)]) || []
   end
 
   def system_created
@@ -235,5 +231,9 @@ class SolrDocument
     else
       Rails.application.routes.url_helpers.url_for(only_path: false, action: 'show', host: CatalogController.blacklight_config.oai[:provider][:repository_url], controller: "hyrax/#{self['has_model_ssim'].first.to_s.underscore.pluralize}", id: id)
     end
+  end
+
+  def abstract
+     nested_ordered_abstract_label.present? ? nested_ordered_abstract_label : self[Solrizer.solr_name('abstract', :stored_searchable)] || []
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -99,6 +99,10 @@ class SolrDocument
      nested_ordered_abstract_label.present? ? nested_ordered_abstract_label : self[Solrizer.solr_name('abstract', :stored_searchable)]
   end
 
+  def additional_information
+     nested_ordered_additional_information_label.present? ? nested_ordered_additional_information_label : self[Solrizer.solr_name('additional_information', :stored_searchable)]
+  end
+
   def nested_ordered_abstract_label
     ScholarsArchive::OrderedParserService.parse(self[Solrizer.solr_name('nested_ordered_abstract_label', :symbol)])
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe SolrDocument do
     context "when there are only ordered abstracts" do
       it "should return their labels" do
         document = described_class.new({
-                                           "nested_ordered_abstract_label_tesim" => ["abstractA$0", 'abstractB$1']
+                                           "nested_ordered_abstract_label_ssim" => ["abstractA$0", 'abstractB$1']
                                        })
         expect(document.abstract).to eq ['abstractA', 'abstractB']
       end
@@ -192,7 +192,7 @@ RSpec.describe SolrDocument do
       it "should return their labels" do
         document = described_class.new({
                                            "abstract_tesim" => ['abstractA','abstractB'],
-                                           "nested_ordered_abstract_label_tesim" => ["abstractC$0", 'abstractD$1'],
+                                           "nested_ordered_abstract_label_ssim" => ["abstractC$0", 'abstractD$1'],
                                        })
         expect(document.abstract).to eq ['abstractC', 'abstractD']
       end
@@ -211,7 +211,7 @@ RSpec.describe SolrDocument do
     context "when there are only ordered additional_informations" do
       it "should return their labels" do
         document = described_class.new({
-                                           "nested_ordered_additional_information_label_tesim" => ["additional_informationA$0", 'additional_informationB$1']
+                                           "nested_ordered_additional_information_label_ssim" => ["additional_informationA$0", 'additional_informationB$1']
                                        })
         expect(document.additional_information).to eq ['additional_informationA', 'additional_informationB']
       end
@@ -227,7 +227,7 @@ RSpec.describe SolrDocument do
     context "when there are both core metadata creators and ordered additional_informations" do
       it "should return their labels" do
         document = described_class.new({
-                                           "additional_information_tesim" => ['additional_informationA','additional_informationB'],
+                                           "additional_information_ssim" => ['additional_informationA','additional_informationB'],
                                            "nested_ordered_additional_information_label_ssim" => ["additional_informationC$0", 'additional_informationD$1'],
                                        })
         expect(document.additional_information).to eq ['additional_informationC', 'additional_informationD']

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -163,6 +163,78 @@ RSpec.describe SolrDocument do
     end
   end
 
+  describe "#abstract" do
+    context "when there are no core metadata abstracts and no ordered abstracts" do
+      it "should return an empty array" do
+        document = described_class.new({
+                                           "abstract_tesim" => []
+                                       })
+        expect(document.abstract).to eq []
+      end
+    end
+    context "when there are only ordered abstracts" do
+      it "should return their labels" do
+        document = described_class.new({
+                                           "nested_ordered_abstract_label_ssim" => ["abstractA$0", 'abstractB$1']
+                                       })
+        expect(document.abstract).to eq ['abstractA', 'abstractB']
+      end
+    end
+    context "when there are only core metadata abstracts" do
+      it "should return their labels" do
+        document = described_class.new({
+                                           "abstract_tesim" => ['abstractB','abstractA']
+                                       })
+        expect(document.abstract).to eq ['abstractB', 'abstractA']
+      end
+    end
+    context "when there are both core metadata creators and ordered abstracts" do
+      it "should return their labels" do
+        document = described_class.new({
+                                           "abstract_tesim" => ['abstractA','abstractB'],
+                                           "nested_ordered_abstract_label_ssim" => ["abstractC$0", 'abstractD$1'],
+                                       })
+        expect(document.abstract).to eq ['abstractC', 'abstractD']
+      end
+    end
+  end
+
+  describe "#additional_information" do
+    context "when there are no core metadata additional_informations and no ordered additional_informations" do
+      it "should return an empty array" do
+        document = described_class.new({
+                                           "additional_information_tesim" => []
+                                       })
+        expect(document.additional_information).to eq []
+      end
+    end
+    context "when there are only ordered additional_informations" do
+      it "should return their labels" do
+        document = described_class.new({
+                                           "nested_ordered_additional_information_label_ssim" => ["additional_informationA$0", 'additional_informationB$1']
+                                       })
+        expect(document.additional_information).to eq ['additional_informationA', 'additional_informationB']
+      end
+    end
+    context "when there are only core metadata additional_informations" do
+      it "should return their labels" do
+        document = described_class.new({
+                                           "additional_information_tesim" => ['additional_informationB','additional_informationA']
+                                       })
+        expect(document.additional_information).to eq ['additional_informationB', 'additional_informationA']
+      end
+    end
+    context "when there are both core metadata creators and ordered additional_informations" do
+      it "should return their labels" do
+        document = described_class.new({
+                                           "additional_information_tesim" => ['additional_informationA','additional_informationB'],
+                                           "nested_ordered_additional_information_label_ssim" => ["additional_informationC$0", 'additional_informationD$1'],
+                                       })
+        expect(document.additional_information).to eq ['additional_informationC', 'additional_informationD']
+      end
+    end
+  end
+
   describe "#nested_ordered_title" do
     context "when there are no ordered titles" do
       it "should return an empty array" do

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -175,12 +175,12 @@ RSpec.describe SolrDocument do
     context "when there are only ordered abstracts" do
       it "should return their labels" do
         document = described_class.new({
-                                           "nested_ordered_abstract_label_ssim" => ["abstractA$0", 'abstractB$1']
+                                           "nested_ordered_abstract_label_tesim" => ["abstractA$0", 'abstractB$1']
                                        })
         expect(document.abstract).to eq ['abstractA', 'abstractB']
       end
     end
-    context "when there are only core metadata abstracts" do
+    context "when there are only old abstracts" do
       it "should return their labels" do
         document = described_class.new({
                                            "abstract_tesim" => ['abstractB','abstractA']
@@ -188,11 +188,11 @@ RSpec.describe SolrDocument do
         expect(document.abstract).to eq ['abstractB', 'abstractA']
       end
     end
-    context "when there are both core metadata creators and ordered abstracts" do
+    context "when there are both old and ordered abstracts" do
       it "should return their labels" do
         document = described_class.new({
                                            "abstract_tesim" => ['abstractA','abstractB'],
-                                           "nested_ordered_abstract_label_ssim" => ["abstractC$0", 'abstractD$1'],
+                                           "nested_ordered_abstract_label_tesim" => ["abstractC$0", 'abstractD$1'],
                                        })
         expect(document.abstract).to eq ['abstractC', 'abstractD']
       end
@@ -211,7 +211,7 @@ RSpec.describe SolrDocument do
     context "when there are only ordered additional_informations" do
       it "should return their labels" do
         document = described_class.new({
-                                           "nested_ordered_additional_information_label_ssim" => ["additional_informationA$0", 'additional_informationB$1']
+                                           "nested_ordered_additional_information_label_tesim" => ["additional_informationA$0", 'additional_informationB$1']
                                        })
         expect(document.additional_information).to eq ['additional_informationA', 'additional_informationB']
       end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -127,6 +127,42 @@ RSpec.describe SolrDocument do
     end
   end
 
+  describe "#creator" do
+    context "when there are no core metadata creators and no ordered creators" do
+      it "should return an empty array" do
+        document = described_class.new({
+                                           "creator_tesim" => []
+                                       })
+        expect(document.creator).to eq []
+      end
+    end
+    context "when there are only ordered creators" do
+      it "should return their labels" do
+        document = described_class.new({
+                                           "nested_ordered_creator_label_ssim" => ["creatorA$0", 'creatorB$1']
+                                       })
+        expect(document.creator).to eq ['creatorA', 'creatorB']
+      end
+    end
+    context "when there are only core metadata creators" do
+      it "should return their labels" do
+        document = described_class.new({
+                                           "creator_tesim" => ['creatorB','creatorA']
+                                       })
+        expect(document.creator).to eq ['creatorB', 'creatorA']
+      end
+    end
+    context "when there are both core metadata creators and ordered creators" do
+      it "should return their labels" do
+        document = described_class.new({
+                                           "creator_tesim" => ['creatorA','creatorB'],
+                                           "nested_ordered_creator_label_ssim" => ["creatorC$0", 'creatorD$1'],
+                                       })
+        expect(document.creator).to eq ['creatorC', 'creatorD']
+      end
+    end
+  end
+
   describe "#nested_ordered_title" do
     context "when there are no ordered titles" do
       it "should return an empty array" do


### PR DESCRIPTION
fixes https://github.com/osulp/Scholars-Archive/issues/1670

Update: It turns out that the method `creator` was returning `nil` in some works on staging, causing the submissions queue to break since the view is expecting an array on `creator` from solr.

- added `additional_information` to access old metadata during migration
- added `title_tesim` as suggested by @wickr (`title_tesim` would be based on ordered title part of `nested_ordered_title_tesim`
- updated solr document and fixed the nil issue on `creator` (it now fallbacks to `[]` if it's not available)

TODO:

- [x] fix solr document spec 

