### PR TITLE
fixes Sidekiq administration functions

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,10 @@
+require 'sidekiq/web'
+Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
+Sidekiq::Web.set :sessions,       Rails.application.config.session_options
+Sidekiq::Web.class_eval do
+  use Rack::Protection, origin_whitelist: ['https://ir.library.oregonstate.edu'] # resolve Rack Protection HttpOrigin
+end
+
 config = YAML.safe_load(ERB.new(IO.read(Rails.root + 'config' + 'redis.yml')).result)[Rails.env].with_indifferent_access
 
 redis_conn = { url: "redis://#{config[:host]}:#{config[:port]}/" }


### PR DESCRIPTION
A recent update of Sidekiq (or Rails?) caused the delete and retry functionality to stop working a return an HTTP 403 Forbidden. This has fixed it, but will require a modification for Rails >= 5.2 eventually.

https://github.com/mperham/sidekiq/issues/2560