### PR TITLE
added proper labels to search facets and tag

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -35,6 +35,10 @@ en:
           date_collected: "Date Collected"
           date_valid: "Date Valid"
           resource_type_sim: "Resource Type"
+          creator_sim: "Creator"
+        nested_related_items_label_ssim: "Related Items"
+        nested_ordered_creator_label_ssim: "Creator"
+        nested_ordered_contributor_label_ssim: "Contributor"
       form:
         nested_geo_points: "Geographic Points"
         nested_geo_bbox: "Bounding Box"


### PR DESCRIPTION
Fixes
https://github.com/osulp/Scholars-Archive/issues/1684

It looks like we can set labels for custom field names used for query searching.

The trick is to define it right below search > fields
https://github.com/projectblacklight/blacklight/blob/v6.15.0/config/locales/blacklight.en.yml#L212