### PR TITLE
Fix batch upload forms with nested fields

### DIFF
--- a/app/forms/hyrax/forms/batch_upload_form.rb
+++ b/app/forms/hyrax/forms/batch_upload_form.rb
@@ -9,7 +9,7 @@ module Hyrax
       self.model_class = BatchUploadItem
       include HydraEditor::Form::Permissions
 
-      self.terms -= [:title, :resource_type, :creator, :nested_ordered_title, :nested_ordered_additional_information]
+      self.terms -= [:title, :resource_type, :creator, :nested_ordered_title]
       self.required_fields -= [:keyword, :resource_type]
 
       attr_accessor :payload_concern # a Class name: what is form creating a batch of?

--- a/app/forms/hyrax/forms/batch_upload_form.rb
+++ b/app/forms/hyrax/forms/batch_upload_form.rb
@@ -9,7 +9,7 @@ module Hyrax
       self.model_class = BatchUploadItem
       include HydraEditor::Form::Permissions
 
-      self.terms -= [:title, :resource_type, :creator]
+      self.terms -= [:title, :resource_type, :creator, :nested_ordered_title, :nested_ordered_additional_information]
       self.required_fields -= [:keyword, :resource_type]
 
       attr_accessor :payload_concern # a Class name: what is form creating a batch of?
@@ -25,7 +25,7 @@ module Hyrax
 
       # On the batch upload, title is set per-file.
       def primary_terms
-        [:alt_title, :contributor, :abstract, :license, :doi, :identifier, :bibliographic_citation, :academic_affiliation, :other_affiliation, :in_series, :subject, :tableofcontents, :rights_statement] | super - [:title, :resource_type]
+        [:alt_title, :nested_ordered_creator, :contributor, :nested_ordered_abstract, :license, :doi, :identifier, :bibliographic_citation, :academic_affiliation, :other_affiliation, :in_series, :subject, :tableofcontents, :rights_statement] | super - [:title, :nested_ordered_title, :resource_type]
       end
 
       # # On the batch upload, title is set per-file.

--- a/app/forms/hyrax/forms/batch_upload_form.rb
+++ b/app/forms/hyrax/forms/batch_upload_form.rb
@@ -10,7 +10,7 @@ module Hyrax
       include HydraEditor::Form::Permissions
 
       self.terms -= [:title, :resource_type, :creator, :nested_ordered_title]
-      self.required_fields -= [:keyword, :resource_type]
+      self.required_fields -= [:keyword, :resource_type, :nested_ordered_title]
 
       attr_accessor :payload_concern # a Class name: what is form creating a batch of?
 

--- a/app/models/concerns/scholars_archive/has_nested_ordered_properties.rb
+++ b/app/models/concerns/scholars_archive/has_nested_ordered_properties.rb
@@ -87,31 +87,31 @@ module ScholarsArchive
       # input: [#<NestedOrderedTitle: ...>, #<NestedOrderedTitle: ...>, ""]
       # output: [["Another Title", "1"], ["My Title", "0"]]
       def validate_titles
-        nested_ordered_title.select { |i| (i.instance_of? NestedOrderedTitle) ? (i.title.present? && i.index.present?) : i.present? }
+        nested_ordered_title.select { |i| (i.instance_of? NestedOrderedTitle) && (i.index.first.present? && i.title.first.present?) && (i.index.first.instance_of? String) && (i.title.first.instance_of? String) }
           .map{|i| (i.instance_of? NestedOrderedTitle) ? [i.title.first, i.index.first] : [i] }
           .select(&:present?)
       end
 
       def validate_creators
-        nested_ordered_creator.select { |i| (i.instance_of? NestedOrderedCreator) ? (i.creator.present? && i.index.present?) : i.present? }
+        nested_ordered_creator.select { |i| (i.instance_of? NestedOrderedCreator) && (i.index.first.present? && i.creator.first.present?) && (i.index.first.instance_of? String) && (i.creator.first.instance_of? String) }
           .map{|i| (i.instance_of? NestedOrderedCreator) ? [i.creator.first, i.index.first] : [i] }
           .select(&:present?)
       end
 
       def validate_abstracts
-        nested_ordered_abstract.select { |i| (i.instance_of? NestedOrderedAbstract) ? (i.abstract.present? && i.index.present?) : i.present?}
+        nested_ordered_abstract.select { |i| (i.instance_of? NestedOrderedAbstract) && (i.index.first.present? && i.abstract.first.present?) && (i.index.first.instance_of? String) && (i.abstract.first.instance_of? String) }
           .map{|i| (i.instance_of? NestedOrderedAbstract) ? [i.abstract.first, i.index.first] : [i] }
           .select(&:present?)
       end
 
       def validate_contributors
-        nested_ordered_contributor.select { |i| (i.instance_of? NestedOrderedContributor) ? (i.contributor.present? && i.index.present?) : i.present? }
+        nested_ordered_contributor.select { |i| (i.instance_of? NestedOrderedContributor) && (i.index.first.present? && i.contributor.first.present?) && (i.index.first.instance_of? String) && (i.contributor.first.instance_of? String) }
           .map{|i| (i.instance_of? NestedOrderedContributor) ? [i.contributor.first, i.index.first] : [i] }
           .select(&:present?)
       end
 
       def validate_info
-        nested_ordered_additional_information.select { |i| (i.instance_of? NestedOrderedAdditionalInformation) ? (i.additional_information.present? && i.index.present?) : i.present? }
+        nested_ordered_additional_information.select { |i| (i.instance_of? NestedOrderedAdditionalInformation) && (i.index.first.present? && i.additional_information.first.present?) && (i.index.first.instance_of? String) && (i.additional_information.first.instance_of? String) }
           .map{|i| (i.instance_of? NestedOrderedAdditionalInformation) ? [i.additional_information.first, i.index.first] : [i] }
           .select(&:present?)
       end

--- a/config/initializers/batch_create_job_hack.rb
+++ b/config/initializers/batch_create_job_hack.rb
@@ -1,0 +1,25 @@
+# OVERRIDE: This overrides create on BatchCreateJob and adds
+# nested_ordered_title to the list of attributes
+#
+# Base file: https://github.com/samvera/hyrax/blob/v2.3.0/app/jobs/batch_create_job.rb
+BatchCreateJob.class_eval do
+  def create(user, titles, resource_types, uploaded_files, attributes, operation)
+    model = attributes.delete(:model) || attributes.delete('model')
+    raise ArgumentError, 'attributes must include "model" => ClassName.to_s' unless model
+    uploaded_files.each do |upload_id|
+      title = [titles[upload_id]] if titles[upload_id]
+      # build hash nested_ordered_title for NestedOrderedTitle
+      nested_ordered_title = { rand(DateTime.now.to_i).to_s => { "index" => "0", "title" => title.first.to_s}} if title.first.present?
+      resource_type = Array.wrap(resource_types[upload_id]) if resource_types[upload_id]
+
+      attributes = attributes.merge(uploaded_files: [upload_id],
+                                    title: title,
+                                    nested_ordered_title_attributes: nested_ordered_title,
+                                    resource_type: resource_type)
+      child_operation = Hyrax::Operation.create!(user: user,
+                                                 operation_type: "Create Work",
+                                                 parent: operation)
+      CreateWorkJob.perform_later(user, model, attributes, child_operation)
+    end
+  end
+end


### PR DESCRIPTION
fixes #1689 

- updated `batch_upload_form` to include missing ordered attributes
- added override for `BatchCreateJob` to set `nested_ordered_title_attributes` hash so that it is also based on the filename like `title`.