### PR TITLE
fixes in-place migration to use AF::Base

### DIFF
--- a/app/controllers/concerns/scholars_archive/works_controller_behavior.rb
+++ b/app/controllers/concerns/scholars_archive/works_controller_behavior.rb
@@ -6,8 +6,8 @@ module ScholarsArchive
       before_action :migrate_work_in_place, only: [:edit, :show]
 
       def migrate_work_in_place
-        @curation_concern = _curation_concern_type.find(params[:id]) unless curation_concern
-        unless Migrator.has_migrated?(work: curation_concern)
+        work = ActiveFedora::Base.find(params[:id])
+        unless Migrator.has_migrated?(work: work)
           render("/scholars_archive/migration/migration_failed.html.haml", status: 404) and return
         end
       end


### PR DESCRIPTION
Doesn't try to operate in the same context as the work type that is set by the controller, the migration code doesn't have anything that cares about work-type in this regard. So, in-place migration just queries the work, does the migration if necessary, and gets out of the way for the controller to do what it would naturally do.