### PR TITLE
For Featured Works and Recent Documents on homepage, change Depositor to Creator

### DIFF
--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -7,8 +7,9 @@
       <% end %>
     </h3>
   </div>
-  <div class="featured-field featured-item-depositor">
-    <span class="featured-label"><%= t('hyrax.homepage.featured_works.document.depositor_label') %>:</span> <%= link_to_profile featured.depositor(t('hyrax.homepage.featured_works.document.depositor_missing')) %>
+<%# OVERRIDE: (2018-10-16) Changed Depositor to Creator %>
+  <div class="featured-field featured-item-creator">
+    <span class="featured-label"><%= t('hyrax.homepage.featured_works.document.creator_label') %>:</span> <%= link_to_facet_list(featured.creator, 'creator', t('hyrax.homepage.featured_works.document.creator_missing')) %>
   </div>
 <%# OVERRIDE: (2018-10-16) Changed keywords to Subject %>
   <div class="featured-field featured-item-subject">

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -8,10 +8,10 @@
     <div class="col-sm-10">
       <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span><h3><%= link_to recent_document.to_s, [main_app, recent_document] %></h3>
       <p>
-        <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.depositor_label') %>:</span> <%= link_to_profile recent_document.depositor(t('hyrax.homepage.recently_uploaded.document.depositor_missing')) %>
+        <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.creator_label') %>:</span> <%= link_to_facet_list(recent_document.creator.first(5), 'creator', t('hyrax.homepage.recently_uploaded.document.creator_missing')).html_safe %>
       </p>
       <p>
-        <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.subject_label') %>:</span> <%= link_to_facet_list(recent_document.subject, 'subject', t('hyrax.homepage.recently_uploaded.document.subject_missing')).html_safe %>
+        <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.subject_label') %>:</span> <%= link_to_facet_list(recent_document.subject.first(5), 'subject', t('hyrax.homepage.recently_uploaded.document.subject_missing')).html_safe %>
       </p>
     </div>
   </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -90,9 +90,11 @@ en:
     homepage:
       featured_works:
         document:
-          subject_label: Subjects
+          creator_label: Creator
+          subject_label: Subject
           subject_missing: no subjects specified
       recently_uploaded:
         document:
-          subject_label: Subjects
+          creator_label: Creator
+          subject_label: Subject
           subject_missing: no subjects specified


### PR DESCRIPTION
Limited display of creators and subjects to 5.
Also changed labels to singular form to match the attribute display on a work show page.

Related to #1012 

Featured Works:
![image](https://user-images.githubusercontent.com/2293544/47052406-fe649080-d15c-11e8-9f09-bd33ef5f5743.png)

Recently Uploaded:
![image](https://user-images.githubusercontent.com/2293544/47052419-16d4ab00-d15d-11e8-8f02-4ffd3f1be5cc.png)

