### PR TITLE
update solr doc to exclude empty strings

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -30,7 +30,12 @@ class SolrDocument
   def self.solrized_methods(property_names)
     property_names.each do |property_name|
       define_method property_name.to_sym do
-        self[Solrizer.solr_name(property_name)]
+        values = self[Solrizer.solr_name(property_name)]
+        if values.respond_to?(:each)
+          values.reject(&:blank?)
+        else
+          values
+        end
       end
     end
   end


### PR DESCRIPTION
fixes https://github.com/osulp/Scholars-Archive/issues/1709

It looks like this is happening for fields that contain only one empty string in the value like the case with `conference_name = [""]` 

For some reason, when the renderer checks for blank values, it doesn't hide it because `[""].blank?` evaluates to false instead of true. The renderer expects this to evaluate to true to hide the field: https://github.com/samvera/hyrax/blob/v2.3.0/app/renderers/hyrax/renderers/attribute_renderer.rb#L40

This update cleans empty strings so we get `[]` instead of `[""]` for the presenter/attribute renderers.