### PR TITLE
[WIP] Add default index to ordered fields

### DIFF
--- a/app/forms/scholars_archive/nested_behavior.rb
+++ b/app/forms/scholars_archive/nested_behavior.rb
@@ -15,12 +15,12 @@ module ScholarsArchive
 
       def initialize_fields
         model.nested_geo.build
-        model.nested_related_items.build
-        model.nested_ordered_creator.build
-        model.nested_ordered_title.build
-        model.nested_ordered_abstract.build
-        model.nested_ordered_contributor.build
-        model.nested_ordered_additional_information.build
+        model.nested_related_items.build({index:"0"})
+        model.nested_ordered_creator.build({index:"0"})
+        model.nested_ordered_title.build({index:"0"})
+        model.nested_ordered_abstract.build({index:"0"})
+        model.nested_ordered_contributor.build({index:"0"})
+        model.nested_ordered_additional_information.build({index:"0"})
         super
       end
 

--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -290,11 +290,11 @@ module ScholarsArchive
       accepts_nested_attributes_for :nested_geo, :allow_destroy => true, :reject_if => :all_blank
       accepts_nested_attributes_for :nested_related_items, :allow_destroy => true, :reject_if => :all_blank
       # reject if all attributes all blank OR if either index or creator is blank
-      accepts_nested_attributes_for :nested_ordered_title, :allow_destroy => true, :reject_if => proc { |attributes| attributes[:index].blank? || attributes[:title].blank? || attributes.all? { |key, value| key == "_destroy" || value.blank? } }
-      accepts_nested_attributes_for :nested_ordered_creator, :allow_destroy => true, :reject_if => proc { |attributes| attributes[:index].blank? || attributes[:creator].blank? || attributes.all? { |key, value| key == "_destroy" || value.blank? } }
-      accepts_nested_attributes_for :nested_ordered_abstract, :allow_destroy => true, :reject_if => proc { |attributes| attributes[:index].blank? || attributes[:abstract].blank? || attributes.all? { |key, value| key == "_destroy" || value.blank? } }
-      accepts_nested_attributes_for :nested_ordered_contributor, :allow_destroy => true, :reject_if => proc { |attributes| attributes[:index].blank? || attributes[:contributor].blank? || attributes.all? { |key, value| key == "_destroy" || value.blank? } }
-      accepts_nested_attributes_for :nested_ordered_additional_information, :allow_destroy => true, :reject_if => proc { |attributes| attributes[:index].blank? || attributes[:additional_information].blank? || attributes.all? { |key, value| key == "_destroy" || value.blank? } }
+      accepts_nested_attributes_for :nested_ordered_title, :allow_destroy => true, :reject_if => proc { |attributes| attributes[:title].blank? || attributes.all? { |key, value| key == "_destroy" || value.blank? } }
+      accepts_nested_attributes_for :nested_ordered_creator, :allow_destroy => true, :reject_if => proc { |attributes| attributes[:creator].blank? || attributes.all? { |key, value| key == "_destroy" || value.blank? } }
+      accepts_nested_attributes_for :nested_ordered_abstract, :allow_destroy => true, :reject_if => proc { |attributes| attributes[:abstract].blank? || attributes.all? { |key, value| key == "_destroy" || value.blank? } }
+      accepts_nested_attributes_for :nested_ordered_contributor, :allow_destroy => true, :reject_if => proc { |attributes| attributes[:contributor].blank? || attributes.all? { |key, value| key == "_destroy" || value.blank? } }
+      accepts_nested_attributes_for :nested_ordered_additional_information, :allow_destroy => true, :reject_if => proc { |attributes| attributes[:additional_information].blank? || attributes.all? { |key, value| key == "_destroy" || value.blank? } }
     end
   end
 end

--- a/spec/models/default_spec.rb
+++ b/spec/models/default_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Default do
       g
     }
 
-
     let(:date) { "2022-01-01" }
     let(:facet) { asset.to_solr["date_facet_yearly_ssim"] }
 
@@ -300,20 +299,27 @@ RSpec.describe Default do
       ]
       expect(g.nested_ordered_creator.length).to eq 0
     end
-    it "should not persist items when either one of the attributes are blank" do
+    it "should not persist item when only creator is blank" do
       g = described_class.new()
       g.nested_ordered_title_attributes = nested_ordered_title_attributes
       g.nested_ordered_creator_attributes = [
-          {
-              :index => "",
-              :creator => "CreatorA"
-          },
           {
               :index => "1",
               :creator => ""
           }
       ]
       expect(g.nested_ordered_creator.length).to eq 0
+    end
+    it "should persist item when only index is blank" do
+      g = described_class.new()
+      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      g.nested_ordered_label_attributes = [
+          {
+              :index => "",
+              :creator => "CreatorA"
+          }
+      ]
+      expect(g.nested_ordered_creator.length).to eq 1
     end
     it "should work on already persisted items" do
       g = described_class.new()
@@ -364,6 +370,100 @@ RSpec.describe Default do
     expect(g.nested_ordered_creator.map{|x| x.creator.first}).to contain_exactly("Creator1","Creator2")
   end
 
+  describe "#nested_related_items_attributes" do
+    let(:attributes) do
+      [{
+           :index => "0",
+           :label => "LabelA",
+           :related_url => "UrlA"
+       }]
+    end
+    
+    it "should be able to delete items" do
+      g = described_class.new()
+      g.nested_related_items_attributes = attributes
+      g.nested_related_items_attributes = [
+          {
+              :id => g.nested_related_items.first.id,
+              :_destroy => true
+          },
+          {
+              :index => "1",
+              :label => "LabelB",
+              :related_url => "UrlB"
+          }
+      ]
+      expect(g.nested_related_items.length).to eq 1
+      expect(g.nested_related_items.first.label).to eq ["LabelB"]
+    end
+    it "should not persist items when all are blank" do
+      g = described_class.new()
+      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      g.nested_related_items_attributes = [
+          {
+              :index => "",
+              :label => "",
+              :related_url => ""
+          },
+          {
+              :index => "",
+              :label => "",
+              :related_url => ""
+          }
+      ]
+      expect(g.nested_related_items.length).to eq 0
+    end
+    
+    it "should work on already persisted items" do
+      g = described_class.new()
+      g.nested_related_items_attributes = attributes
+      expect(g.nested_related_items.first.label).to eq ["LabelA"]
+    end
+    it "should be able to edit" do
+      g = described_class.new()
+      g.nested_related_items_attributes = attributes
+      expect(g.nested_related_items.length).to eq 1
+      expect(g.nested_related_items.first.label).to eq ["LabelA"]
+
+      g.nested_related_items.first.label = ["LabelB"]
+      g.nested_related_items.first.persist!
+      expect(g.nested_related_items.length).to eq 1
+      expect(g.nested_related_items.first.label).to eq ["LabelB"]
+    end
+    it "should not create blank ones" do
+      g = described_class.new(keyword: ['test'])
+      g.nested_related_items_attributes = [
+          {
+              :index => "",
+              :label => "",
+              :related_url => ""
+          }
+      ]
+      expect(g.nested_related_items.length).to eq 0
+    end
+  end
+
+  it "should be able to create multiple nested related items with order index" do
+    g = described_class.new()
+    g.nested_related_items_attributes = nested_related_items_attributes
+    g.nested_related_items_attributes = [
+        {
+          "index" => "0",
+          "related_url" => "ItemUrl1",
+          "label" =>"Label1"
+        },
+        {
+          "index" => "1",
+          "related_url" => "ItemUrl2",
+          "label" =>"Label2"
+        }
+    ]
+    expect(g.nested_related_items.length).to eq 2
+    expect(g.nested_related_items.map{|x| x.index.first}).to contain_exactly("0","1")
+    expect(g.nested_related_items.map{|x| x.related_url.first}).to contain_exactly("ItemUrl1","ItemUrl2")
+    expect(g.nested_related_items.map{|x| x.label.first}).to contain_exactly("Label1","Label2")
+  end
+
   describe "#nested_ordered_title_attributes" do
     let(:attributes) do
       [{
@@ -401,20 +501,28 @@ RSpec.describe Default do
       ]
       expect(g.nested_ordered_title.length).to eq 0
     end
-    it "should not persist items when either one of the attributes are blank" do
+
+    it "should not persist item when only title is blank" do
       g = described_class.new()
       g.nested_ordered_title_attributes = [
-        {
-          :index => "",
-          :title => "TitleA"
-        },
-        {
-          :index => "1",
-          :title => ""
-        }
+          {
+              :index => "1",
+              :title => ""
+          }
       ]
       expect(g.nested_ordered_title.length).to eq 0
     end
+    it "should persist item when only index is blank" do
+      g = described_class.new()
+      g.nested_ordered_title_attributes = [
+          {
+              :index => "",
+              :title => "TitleA"
+          }
+      ]
+      expect(g.nested_ordered_title.length).to eq 1
+    end
+
     it "should work on already persisted items" do
       g = described_class.new()
       g.nested_ordered_title_attributes = attributes
@@ -500,21 +608,28 @@ RSpec.describe Default do
       ]
       expect(g.nested_ordered_contributor.length).to eq 0
     end
-    it "should not persist items when either one of the attributes are blank" do
+
+    it "should not persist item when only contributor is blank" do
       g = described_class.new()
-      g.nested_ordered_title_attributes = nested_ordered_title_attributes
       g.nested_ordered_contributor_attributes = [
-        {
-          :index => "",
-          :contributor => "ContributorA"
-        },
-        {
-          :index => "1",
-          :contributor => ""
-        }
+          {
+              :index => "1",
+              :contributor => ""
+          }
       ]
       expect(g.nested_ordered_contributor.length).to eq 0
     end
+    it "should persist item when only index is blank" do
+      g = described_class.new()
+      g.nested_ordered_contributor_attributes = [
+          {
+              :index => "",
+              :contributor => "ContributorA"
+          }
+      ]
+      expect(g.nested_ordered_contributor.length).to eq 1
+    end
+
     it "should work on already persisted items" do
       g = described_class.new()
       g.nested_ordered_title_attributes = nested_ordered_title_attributes
@@ -586,21 +701,29 @@ RSpec.describe Default do
       ]
       expect(g.nested_ordered_abstract.length).to eq 0
     end
-    it "should not persist items when either one of the attributes are blank" do
+
+    it "should not persist item when only abstract is blank" do
       g = described_class.new()
-      g.nested_ordered_title_attributes = nested_ordered_title_attributes
       g.nested_ordered_abstract_attributes = [
-        {
-          :index => "",
-          :abstract => "AbstractA"
-        },
-        {
-          :index => "1",
-          :abstract => ""
-        }
+          {
+              :index => "1",
+              :abstract => ""
+          }
       ]
       expect(g.nested_ordered_abstract.length).to eq 0
     end
+
+    it "should persist item when only index is blank" do
+      g = described_class.new()
+      g.nested_ordered_abstract_attributes = [
+          {
+              :index => "",
+              :abstract => "AbstractA"
+          }
+      ]
+      expect(g.nested_ordered_abstract.length).to eq 1
+    end
+
     it "should work on already persisted items" do
       g = described_class.new()
       g.nested_ordered_title_attributes = nested_ordered_title_attributes

--- a/spec/models/default_spec.rb
+++ b/spec/models/default_spec.rb
@@ -445,7 +445,7 @@ RSpec.describe Default do
 
   it "should be able to create multiple nested related items with order index" do
     g = described_class.new()
-    g.nested_related_items_attributes = nested_related_items_attributes
+    g.nested_related_items_attributes = attributes
     g.nested_related_items_attributes = [
         {
           "index" => "0",

--- a/spec/models/default_spec.rb
+++ b/spec/models/default_spec.rb
@@ -445,7 +445,6 @@ RSpec.describe Default do
 
   it "should be able to create multiple nested related items with order index" do
     g = described_class.new()
-    g.nested_related_items_attributes = attributes
     g.nested_related_items_attributes = [
         {
           "index" => "0",

--- a/spec/models/default_spec.rb
+++ b/spec/models/default_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe Default do
     it "should persist item when only index is blank" do
       g = described_class.new()
       g.nested_ordered_title_attributes = nested_ordered_title_attributes
-      g.nested_ordered_label_attributes = [
+      g.nested_ordered_creator_attributes = [
           {
               :index => "",
               :creator => "CreatorA"
@@ -398,7 +398,7 @@ RSpec.describe Default do
     end
     it "should not persist items when all are blank" do
       g = described_class.new()
-      g.nested_ordered_title_attributes = nested_ordered_title_attributes
+      g.nested_ordered_title_attributes = attributes
       g.nested_related_items_attributes = [
           {
               :index => "",


### PR DESCRIPTION
- updated nested ordered fields to default index to 0 when building the initial object
- updated default model to reject items when all fields are blank or when only the content is blank
- recovered original param entries from the logs to reset creator and title for https://ir.library.oregonstate.edu/concern/graduate_projects/n009w719j