### PR TITLE
Uses creator_sim for facets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ fits.log
 /public/assets*
 /public/branding*
 docker-compose.override.yml
+
+revisions.log
+migration.csv

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -72,7 +72,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('contributor_committeemember', :facetable), limit: 5, label: 'Committee Member'
     config.add_facet_field solr_name('conference_name', :facetable), limit: 5, label: 'Conference Name'
     config.add_facet_field solr_name('conference_section', :facetable), limit: 5, label: 'Conference Section/Track'
-    config.add_facet_field "nested_ordered_creator_label_ssim", label: "Creator", limit: 5, helper_method: :parsed_index
+    config.add_facet_field "creator_ssim", label: "Creator", limit: 5
     config.add_facet_field "nested_ordered_contributor_label_ssim", label: "Contributor", limit: 5, helper_method: :parsed_index
 
 #    config.add_facet_field 'date_facet_yearly_ssim', :label => 'Date', :range => true

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -72,7 +72,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('contributor_committeemember', :facetable), limit: 5, label: 'Committee Member'
     config.add_facet_field solr_name('conference_name', :facetable), limit: 5, label: 'Conference Name'
     config.add_facet_field solr_name('conference_section', :facetable), limit: 5, label: 'Conference Section/Track'
-    config.add_facet_field "creator_ssim", label: "Creator", limit: 5
+    config.add_facet_field "creator_sim", label: "Creator", limit: 5
     config.add_facet_field "nested_ordered_contributor_label_ssim", label: "Contributor", limit: 5, helper_method: :parsed_index
 
 #    config.add_facet_field 'date_facet_yearly_ssim', :label => 'Date', :range => true

--- a/app/models/concerns/scholars_archive/has_solr_labels.rb
+++ b/app/models/concerns/scholars_archive/has_solr_labels.rb
@@ -22,6 +22,7 @@ module ScholarsArchive
           labels = point_labels + bbox_labels
           related_items_labels = nested_related_items.map{|i| (i.instance_of? NestedRelatedItems) ? "#{i.label.first}$#{i.related_url.first}$#{i.index.first}" : i }.select(&:present?)
           ordered_creator_labels = nested_ordered_creator.map{|i| (i.instance_of? NestedOrderedCreator) ? "#{i.creator.first}$#{i.index.first}" : i }.select(&:present?)
+          creator_labels = nested_ordered_creator.map{|i| (i.instance_of? NestedOrderedCreator) ? "#{i.creator.first}" : i }.select(&:present?).uniq
           ordered_title_labels = nested_ordered_title.map{|i| (i.instance_of? NestedOrderedTitle) ? "#{i.title.first}$#{i.index.first}" : i }.select(&:present?)
           ordered_abstract_labels = nested_ordered_abstract.map{|i| (i.instance_of? NestedOrderedAbstract) ? "#{i.abstract.first}$#{i.index.first}" : i }.select(&:present?)
           ordered_contributor_labels = nested_ordered_contributor.map{|i| (i.instance_of? NestedOrderedContributor) ? "#{i.contributor.first}$#{i.index.first}" : i }.select(&:present?)
@@ -48,6 +49,7 @@ module ScholarsArchive
           
           doc[ActiveFedora.index_field_mapper.solr_name("rights_statement", :facetable)] = rights_statement.first
           doc[ActiveFedora.index_field_mapper.solr_name("license", :facetable)] = license.first
+          doc['creator_ssim'] = creator_labels
         end
       end
     end

--- a/app/models/concerns/scholars_archive/has_solr_labels.rb
+++ b/app/models/concerns/scholars_archive/has_solr_labels.rb
@@ -49,7 +49,7 @@ module ScholarsArchive
           
           doc[ActiveFedora.index_field_mapper.solr_name("rights_statement", :facetable)] = rights_statement.first
           doc[ActiveFedora.index_field_mapper.solr_name("license", :facetable)] = license.first
-          doc['creator_ssim'] = creator_labels
+          doc['creator_sim'] = creator_labels
         end
       end
     end


### PR DESCRIPTION
Fixes #1745 

This indexes creators on the creator_ssim index field that are unindexed and unique. This is to resolve the issue of duplicate creator labels based on different ordering. Since facets dont need any concept of order, removing the order and just indexing labels allows for the paring down of the length of results and should allow for the searching of creators again. 
<img width="1098" alt="screen shot 2018-11-01 at 9 27 43 am" src="https://user-images.githubusercontent.com/6424683/47865085-8cc14f00-ddb8-11e8-9ce1-27772a06e8d1.png">
