### PR TITLE
added missing indexer to collection model

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -3,4 +3,5 @@ class Collection < ActiveFedora::Base
   include ::Hyrax::CollectionBehavior
   # You can replace these metadata if they're not suitable
   include Hyrax::BasicMetadata
+  self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
 end


### PR DESCRIPTION
fixes #1735
- It turns out that hyrax now has a separate indexer for the Collection model. See the new collection template: https://github.com/samvera/hyrax/blob/v2.3.0/lib/generators/hyrax/templates/app/models/collection.rb#L6
- The metadata for collections in the template is now based on https://github.com/samvera/hyrax/blob/v2.3.0/app/models/concerns/hyrax/basic_metadata.rb

![image](https://user-images.githubusercontent.com/3486120/47866212-5802c700-ddbb-11e8-933c-847f0b83be65.png)

![image](https://user-images.githubusercontent.com/3486120/47866216-5afdb780-ddbb-11e8-8464-063d7c84987a.png)
