### PR TITLE
disables in-place migration since it is finished

### DIFF
--- a/app/controllers/concerns/scholars_archive/works_controller_behavior.rb
+++ b/app/controllers/concerns/scholars_archive/works_controller_behavior.rb
@@ -4,19 +4,11 @@ module ScholarsArchive
     include Hyrax::WorksControllerBehavior
     included do
       before_action :redirect_mismatched_work, only: [:show]
-      before_action :migrate_work_in_place, only: [:edit, :show]
 
       def redirect_mismatched_work
         curation_concern = ActiveFedora::Base.find(params[:id])
         if curation_concern.class != _curation_concern_type
           redirect_to(main_app.polymorphic_path(curation_concern), status: :moved_permanently) and return
-        end
-      end
-
-      def migrate_work_in_place
-        work = ActiveFedora::Base.find(params[:id])
-        unless Migrator.has_migrated?(work: work)
-          render("/scholars_archive/migration/migration_failed.html.haml", status: 404) and return
         end
       end
     end

--- a/config/initializers/work_migrator.rb
+++ b/config/initializers/work_migrator.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal:true
-
-unless Rails.env.test?
-  ::Migrator = ScholarsArchive::MigrateOrderedMetadataService.new(
-    creator_csv_path: ENV.fetch('CREATOR_CSV_PATH', 'tmp/creator_migration.csv'),
-    title_csv_path: ENV.fetch('TITLE_CSV_PATH', 'tmp/title_migration.csv'),
-    contributor_csv_path: ENV.fetch('CONTRIBUTOR_CSV_PATH', 'tmp/contributor_migration.csv')
-  )
-end

--- a/config/local_env.example.yml
+++ b/config/local_env.example.yml
@@ -80,6 +80,3 @@ OSU_API_CLIENT_ID: abc1234
 OSU_API_CLIENT_SECRET: def5678
 OSU_API_PERSON_REFRESH_SECONDS: '<%= 30 * 24 * 60 * 60 %>'
 
-CREATOR_CSV_PATH: /path/to/creator/migration.csv
-TITLE_CSV_PATH: /path/to/title/migration.csv
-CONTRIBUTOR_CSV_PATH: /path/to/contributor/migration.csv


### PR DESCRIPTION
fixes #1760 

I feel like leaving the migration service allows us to use it, in isolation, if we had to process something in particular. 