### PR TITLE
updated solr_facets to fix server error

### DIFF
--- a/app/services/scholars_archive/all_facet_values_service.rb
+++ b/app/services/scholars_archive/all_facet_values_service.rb
@@ -27,15 +27,26 @@ module ScholarsArchive
     def solr_facets(facet_field, params)
       solr_connection = RSolr.connect(url: ActiveFedora.solr_config[:url])
       response = solr_connection.get 'select', params: facet_params(facet_field, params)
+      build_facet_hashes(response['facet_counts']['facet_fields'][facet_field])
+    end
 
-      all_facets = response['facet_counts']['facet_fields'][facet_field]
-      sub_facets_count = all_facets.count / 2
-      if sub_facets_count.odd?
-        hashes = all_facets.each_slice(sub_facets_count - 1).map { |a| Hash[*a] }
-      else
-        hashes = all_facets.each_slice(sub_facets_count).map { |a| Hash[*a] }
-      end
+    ##
+    # Build a hash in the form {"Author A" => 1, "Author B" => 2}
+    # @param all_facets [Array] in the form ["Author A", 1, "Author B", 2]
+    # @returns [Hash] in the form {"Author A" => 1, "Author B" => 2}
+    def build_facet_hashes(all_facets)
+      hashes = all_facets.each_slice(slice_count(all_facets.count)).map { |a| Hash[*a] }
       hashes.inject(&:merge)
+    end
+
+    ##
+    # Calculate proper slice count
+    # @param all_facets_count [Int] the total facets count
+    # @returns [Int] an integer value that represents a total number of facet
+    # groups
+    def slice_count(all_facets_count)
+      sub_facets_count = all_facets_count / 2
+      sub_facets_count.odd? ? sub_facets_count - 1 : sub_facets_count
     end
 
     ##

--- a/app/services/scholars_archive/all_facet_values_service.rb
+++ b/app/services/scholars_archive/all_facet_values_service.rb
@@ -27,7 +27,15 @@ module ScholarsArchive
     def solr_facets(facet_field, params)
       solr_connection = RSolr.connect(url: ActiveFedora.solr_config[:url])
       response = solr_connection.get 'select', params: facet_params(facet_field, params)
-      Hash[*response['facet_counts']['facet_fields'][facet_field]]
+
+      all_facets = response['facet_counts']['facet_fields'][facet_field]
+      sub_facets_count = all_facets.count / 2
+      if sub_facets_count.odd?
+        hashes = all_facets.each_slice(sub_facets_count - 1).map { |a| Hash[*a] }
+      else
+        hashes = all_facets.each_slice(sub_facets_count).map { |a| Hash[*a] }
+      end
+      hashes.inject(&:merge)
     end
 
     ##


### PR DESCRIPTION
fixes #1794 

We can reproduce the server error in the console with:
```
c = RSolr.connect(url: ActiveFedora.solr_config[:url])

p = {:rows=>0, :facet=>"on", "facet.field"=>"creator_sim", "facet.limit"=>100000, "f.creator_sim.facet.limit"=>100000}

r = c.get 'select', params: p

all_facets = r['facet_counts']['facet_fields']['creator_sim']
irb(main):005:0> Hash[*all_facets]
Traceback (most recent call last):
        8: from bin/rails:4:in `<main>'
        7: from bin/rails:4:in `require'
        6: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/railties-5.0.7/lib/rails/commands.rb:18:in `<top (required)>'
        5: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/railties-5.0.7/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
        4: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/railties-5.0.7/lib/rails/commands/commands_tasks.rb:78:in `console'
        3: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/railties-5.0.7/lib/rails/commands/console_helper.rb:9:in `start'
        2: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/railties-5.0.7/lib/rails/commands/console.rb:65:in `start'
        1: from (irb):5
SystemStackError (stack level too deep)
```