### PR TITLE
update bulk update script - check for single value properties

### DIFF
--- a/lib/tasks/bulk_update_csv.rake
+++ b/lib/tasks/bulk_update_csv.rake
@@ -56,7 +56,7 @@ def update_property(logger, work, row)
     return nil
   end
 
-  if property.is_a?(String)
+  if property.is_a?(String) || is_property_multiple?(work, row) == false
     work[row[:property]] = row[:to]&.to_s || ''
     logger.info("#{work.class} #{row[:id]} #{row[:property]} changed from \"#{row[:from]}\" to \"#{row[:to]}\"")
   elsif property.is_a?(ActiveTriples::Relation)
@@ -72,6 +72,11 @@ def update_property(logger, work, row)
     logger.info("#{work.class} #{row[:id]} #{row[:property]} set to \"#{row[:to]}\"")
   end
   work
+end
+
+def is_property_multiple?(work, row)
+  class_model = work.has_model.first.constantize
+  Hyrax::FormMetadataService.multiple?(class_model,row[:property])
 end
 
 def overwrite_multivalue_row(logger, work, row, property)


### PR DESCRIPTION
When the value of `property = work["has_journal"]` is blank, it defaults to a multi-value field that leads to a an ArgumentError:
```
ArgumentError: You attempted to set the property `has_journal' of nk322d32h to an enumerable value. However, this property is declared as singular.
/usr/local/bundle/gems/active-fedora-11.5.2/lib/active_fedora/attributes/property_builder.rb:49:in `has_journal='
/usr/local/bundle/gems/active-fedora-11.5.2/lib/active_fedora/attributes.rb:46:in `[]='
/data/lib/tasks/bulk_update_csv.rake:72:in `update_property'
/data/lib/tasks/bulk_update_csv.rake:47:in `update_work'
/data/lib/tasks/bulk_update_csv.rake:41:in `block in process_csv'
/data/lib/tasks/bulk_update_csv.rake:40:in `process_csv'
/data/lib/tasks/bulk_update_csv.rake:29:in `block (2 levels) in <top (required)>'
/usr/local/bundle/gems/railties-5.0.7/lib/rails/commands/rake_proxy.rb:14:in `block in run_rake_task'
/usr/local/bundle/gems/railties-5.0.7/lib/rails/commands/rake_proxy.rb:11:in `run_rake_task'
/usr/local/bundle/gems/railties-5.0.7/lib/rails/commands/commands_tasks.rb:51:in `run_command!'
/usr/local/bundle/gems/railties-5.0.7/lib/rails/commands.rb:18:in `<top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
Tasks: TOP => scholars_archive:bulk_update_csv
```
Added another option to check single vs multi-value properties in bulk update script

