### PR TITLE
Fix migrate ordered creators cleanup task

### DIFF
--- a/lib/scholars_archive/migrate_ordered_metadata_service.rb
+++ b/lib/scholars_archive/migrate_ordered_metadata_service.rb
@@ -227,7 +227,7 @@ module ScholarsArchive
       #
       # ie. [ 'Ross, Bob', 'Ross, Steve' ]
       csv.select { |l| l[4].casecmp(handle).zero? }
-         .sort_by! { |obj| obj[3] }
+         .sort_by! { |obj| obj[3].to_i }
          .map { |obj| obj[2] }
     end
 

--- a/lib/tasks/migrate_works_10_or_more_items.rake
+++ b/lib/tasks/migrate_works_10_or_more_items.rake
@@ -244,7 +244,7 @@ namespace :scholars_archive do
     # migrate child works (members) if any
     work_id = work.present? ? work.id : nil
     work.members.reject { |m| m.class.to_s == 'FileSet' }.each do |child|
-    log("MigrateOrderedMetadataService(handle:#{handle}, work:#{work_id}) : child_work:#{child.id} : Finding child work, attempting to migrate")
+    log("MigrateOrderedMetadataService(handle:#{handle}, parent_work:#{work_id}) : child_work:#{child.id} : Finding child work, attempting to migrate")
 
     unless creators.empty?
       log("MigrateOrderedMetadataService(handle:#{handle}, parent_work:#{work_id}) : child_work:#{child.id} : Attempting to migrate creators [solr]: child nested_ordered_creator_label_ssim: #{doc['nested_ordered_creator_label_ssim']}")


### PR DESCRIPTION
- fixes sort bug in MigrateOrderedMetadataService
- adds `force_dspace_order_metadata_for_members` to cleanup creators in child members as well