### PR TITLE
add task to get children from handles manually fixed

### DIFF
--- a/lib/tasks/migrate_works_10_or_more_items.rake
+++ b/lib/tasks/migrate_works_10_or_more_items.rake
@@ -46,6 +46,12 @@ namespace :scholars_archive do
     force_migrator_for_order_and_cleanup('r2_handles.csv')
   end
 
+  # Task 1 (R3): Migrate works with creators with child members
+  desc "Migrate dspace creator order and char for child members missed during manual cleanup"
+  task :migrate_dspace_creator_member_cleanup => :environment do
+    force_migrator_for_order_and_cleanup('r3_handles.csv')
+  end
+
   # Task 2: Generate a Json with works that were already fixed manually, or those that were updated before
   # running the migration last year so that we can skip those before running Task 1. Also, generate another one with works to be fixed.
   desc "Generate a CSV with handles containing unclean creators, but exclude works without the unknown symbol (already fixed)"

--- a/lib/tasks/migrate_works_10_or_more_items.rake
+++ b/lib/tasks/migrate_works_10_or_more_items.rake
@@ -310,7 +310,7 @@ namespace :scholars_archive do
 
   def get_work_members(doc)
     work = ActiveFedora::Base.find(doc.id) if doc.respond_to?('id')
-    work.members.reject { |m| m.class.to_s == 'FileSet' }.map {|c| {membed_id: c.id, member_creators: c.creator, member_model: c.has_model.first.underscore.pluralize}}
+    work.members.reject { |m| m.class.to_s == 'FileSet' }.map {|c| {member_id: c.id, member_creators: c.creator, member_model: c.has_model.first.underscore.pluralize}}
   end
 
   def force_dspace_order_metadata_for_members(work, doc, handle, creators, logger)

--- a/lib/tasks/migrate_works_10_or_more_items.rake
+++ b/lib/tasks/migrate_works_10_or_more_items.rake
@@ -173,6 +173,26 @@ namespace :scholars_archive do
 
   end
 
+  # Task 3 (a): Get a final list of handles that need to be fixed.
+  desc "Get all handles that were already fixed at the parent level but missed child works."
+  task :get_all_handles_to_be_fixed_for_x => :environment do
+    # X_with_children = Get all handles from handles_with_unclean_creators_fixed
+    handles_x_with_children = File.join(Rails.root, 'tmp', 'creator_cleanup', 'handles_x_with_children.json')
+    handles_x_with_children_json = File.read(handles_x_with_children)
+    handles_x_with_children_hash = JSON.parse(handles_x_with_children_json)
+
+    # W3 = Get all handles from handles_with_additional_changes_3
+    w3_json_path = File.join(Rails.root, 'tmp', 'creator_cleanup', 'handles_with_additional_changes_3.json')
+    w3_json = File.read(w3_json_path)
+    w3_hash = JSON.parse(w3_json)
+
+    # Handles for Run 3 (R3) fixes child works in group X_with_children except
+    # those that don't match what we have in dspace
+    # R3 = X_with_children - W3
+    r3_handles = handles_x_with_children_hash.keys.uniq - w3_hash.keys.uniq
+    save_to_csv(r3_handles, 'r3_handles.csv')
+  end
+
   # Task 4: Inspect the works to be handled. These works would be a special case and might need to be fixed manually since we wouldn't be
   # able to predict the right order due to migration issues
   desc "Do a compare to find handles that got creators added/removed from the field after migration (w1)"
@@ -194,6 +214,18 @@ namespace :scholars_archive do
 
     get_handles_to_be_manually_fixed(handles_with_10_or_more_creators_json, handles_with_additional_changes_2)
   end
+
+  # Task 6: Inspect the works to be handled. These works would be a special case and might need to be fixed manually since we wouldn't be
+  # able to predict the right order due to migration issues
+  desc "Do a compare to find handles that got creators added/removed during manual cleanup (w2)"
+  task :find_creators_with_additional_changes_w3 => :environment do
+    handles_x_with_children_creators_json = File.join(Rails.root, 'tmp', 'creator_cleanup', 'handles_x_with_children_creators.json')
+
+    handles_with_additional_changes_3 = File.join(Rails.root, 'tmp', 'creator_cleanup', 'handles_with_additional_changes_3.json')
+
+    get_handles_to_be_manually_fixed(handles_x_with_children_creators_json, handles_with_additional_changes_3)
+  end
+
 
   def get_handles_to_be_manually_fixed(to_be_fixed_json, output_json)
     dspace_creator_order_clean_csv_path = File.join(Rails.root, 'tmp', 'creator_cleanup', 'dspace_creator_order_clean.csv')


### PR DESCRIPTION
Related to https://github.com/osulp/Scholars-Archive/issues/1796 

Some works fixed manually have child works that still have unclean creators. My original tasks didn't take into account child works already fixed in https://github.com/osulp/Scholars-Archive/issues/1796#issuecomment-472152751 

This tasks gets a json file with handles, including child works that we can analyze 
```
"handle-url" => [{
  member_id: "ABCDE", 
  member_creators: {"hello","world"},
  member_model: "articles"
}]
```
Update:

I'm also adding another task R3 to generate `r3_handles.csv` of handles with child works that we could run as `scholars_archive:migrate_dspace_creator_member_cleanup`