### PR TITLE
add support to remove items for multivalue fields in bulk updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: Update Debian Packages
           command: |
             echo "deb http://http.debian.net/debian jessie-backports main" | sudo tee -a /etc/apt/sources.list
-            sudo apt-get update -qq
+            sudo apt-get update -qq --fix-missing
             sudo apt-get upgrade -qq
             sudo apt-get install -y -f software-properties-common build-essential default-libmysqlclient-dev mysql-client nodejs make apt-utils
             sudo apt-get install -t jessie-backports -y openjdk-8-jre-headless ca-certificates-java

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: Update Debian Packages
           command: |
             echo "deb http://http.debian.net/debian jessie-backports main" | sudo tee -a /etc/apt/sources.list
-            sudo apt-get update -qq --fix-missing
+            sudo apt-get update -qq
             sudo apt-get upgrade -qq
             sudo apt-get install -y -f software-properties-common build-essential default-libmysqlclient-dev mysql-client nodejs make apt-utils
             sudo apt-get install -t jessie-backports -y openjdk-8-jre-headless ca-certificates-java

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,11 @@ jobs:
       - run:
           name: Update Debian Packages
           command: |
-            echo "deb http://http.debian.net/debian jessie-backports main" | sudo tee -a /etc/apt/sources.list
+            echo "deb http://http.debian.net/debian stretch-backports main" | sudo tee -a /etc/apt/sources.list
             sudo apt-get update -qq
             sudo apt-get upgrade -qq
             sudo apt-get install -y -f software-properties-common build-essential default-libmysqlclient-dev mysql-client nodejs make apt-utils
-            sudo apt-get install -t jessie-backports -y openjdk-8-jre-headless ca-certificates-java
+            sudo apt-get install -t stretch-backports -y openjdk-8-jre-headless ca-certificates-java
             sudo apt-get install -y openjdk-8-jre openjdk-8-jdk openjdk-8-jdk-headless
             sudo update-alternatives --config java
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: Update Debian Packages
           command: |
             echo "deb http://http.debian.net/debian jessie-backports main" | sudo tee -a /etc/apt/sources.list
-            sudo apt-get update -qq --fix-missing
+            sudo apt-get update --fix-missing
             sudo apt-get upgrade -qq
             sudo apt-get install -y -f software-properties-common build-essential default-libmysqlclient-dev mysql-client nodejs make apt-utils
             sudo apt-get install -t jessie-backports -y openjdk-8-jre-headless ca-certificates-java

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: Update Debian Packages
           command: |
             echo "deb http://http.debian.net/debian jessie-backports main" | sudo tee -a /etc/apt/sources.list
-            sudo apt-get update --fix-missing
+            sudo apt-get update -qq --fix-missing
             sudo apt-get upgrade -qq
             sudo apt-get install -y -f software-properties-common build-essential default-libmysqlclient-dev mysql-client nodejs make apt-utils
             sudo apt-get install -t jessie-backports -y openjdk-8-jre-headless ca-certificates-java

--- a/lib/tasks/bulk_update_csv.rake
+++ b/lib/tasks/bulk_update_csv.rake
@@ -64,6 +64,8 @@ def update_property(logger, work, row)
              add_to_multivalue_row(logger, work, row, property)
            elsif row[:from].casecmp('*').zero?
              overwrite_multivalue_row(logger, work, row, property)
+           elsif row[:from].casecmp('-').zero?
+             remove_from_multivalue_row(logger, work, row, property)
            else
              process_if_found_row(logger, work, row, property)
            end
@@ -90,6 +92,13 @@ def add_to_multivalue_row(logger, work, row, property)
   to_value = row[:to]&.to_s
   work[row[:property]] += [to_value&.split('|')].flatten
   logger.info("#{work.class} #{row[:id]} #{property.property} row added \"#{to_value}\"")
+  work
+end
+
+def remove_from_multivalue_row(logger, work, row, property)
+  to_value = row[:to]&.to_s
+  work[row[:property]] = work[row[:property]].to_a - [to_value&.split('|')].flatten
+  logger.info("#{work.class} #{row[:id]} #{property.property} row removed \"#{to_value}\"")
   work
 end
 


### PR DESCRIPTION
Implemented `remove_from_multivalue_row` to support the `-` operator (in the `from` column) and be able to remove specific items from a multi-value field with bulk updates.

Example input CSV:
```
id,from,to,property,
gm80hv32k,-,http://id.loc.gov/authorities/names/no2011160692,subject,
```

This will be helpful to be able to revert changes in combination with the `+` and replace items with the expected type in https://github.com/osulp/Scholars-Archive/issues/1825

Use case:

Input:
```
id,from,to,property,2046
gm80hv32k,-,http://id.loc.gov/authorities/names/no2011160692,subject,
gm80hv32k,+,Technical note (Forest Products Laboratory (U.S.)),subject,
```
Output:
```
Processing bulk update to works in csv: /data/tmp/bulk_edits/test_bulk_edits.csv
Article gm80hv32k subject row removed "http://id.loc.gov/authorities/names/no2011160692"
Article gm80hv32k subject row added "Technical note (Forest Products Laboratory (U.S.))"
```