### PR TITLE
Fix invalid uri

### DIFF
--- a/app/renderers/hyrax/renderers/search_and_external_link_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/search_and_external_link_attribute_renderer.rb
@@ -49,6 +49,7 @@ module Hyrax
       end
 
       def maybe_uri(s)
+        s = Addressable::URI.escape(s) if %w[http https].any? { |p| s.include? p }
         URI.extract(Addressable::URI.escape(s), %w[http https]).first || ''
       end
 

--- a/app/renderers/hyrax/renderers/search_and_external_link_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/search_and_external_link_attribute_renderer.rb
@@ -50,7 +50,7 @@ module Hyrax
 
       def maybe_uri(s)
         s = Addressable::URI.escape(s) if %w[http https].any? { |p| s.include? p }
-        URI.extract(Addressable::URI.escape(s), %w[http https]).first || ''
+        URI.extract(s, %w[http https]).first || ''
       end
 
       def maybe_license_uri(term)


### PR DESCRIPTION
fixes issue when `publisher` is not a uri, so a uri escape is not required.

steps to reproduce the error:

1. set publisher
```
irb(main):002:0> publisher = "Corvallis, Or. : Agricultural Experiment Station. Oregon State College."
=> "Corvallis, Or. : Agricultural Experiment Station. Oregon State College."
```
2. escape special chars
```
irb(main):003:0> Addressable::URI.escape(publisher)
Traceback (most recent call last):
       15: from bin/rails:4:in `<main>'
       14: from bin/rails:4:in `require'
       13: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/railties-5.0.7/lib/rails/commands.rb:18:in `<top (required)>'
       12: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/railties-5.0.7/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
       11: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/railties-5.0.7/lib/rails/commands/commands_tasks.rb:78:in `console'
       10: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/railties-5.0.7/lib/rails/commands/console_helper.rb:9:in `start'
        9: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/railties-5.0.7/lib/rails/commands/console.rb:65:in `start'
        8: from (irb):3
        7: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/addressable-2.5.2/lib/addressable/uri.rb:580:in `encode'
        6: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/addressable-2.5.2/lib/addressable/uri.rb:136:in `parse'
        5: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/addressable-2.5.2/lib/addressable/uri.rb:136:in `new'
        4: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/addressable-2.5.2/lib/addressable/uri.rb:796:in `initialize'
        3: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/addressable-2.5.2/lib/addressable/uri.rb:2355:in `defer_validation'
        2: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/addressable-2.5.2/lib/addressable/uri.rb:799:in `block in initialize'
        1: from /data0/hydra/shared/bundle/ruby/2.5.0/gems/addressable-2.5.2/lib/addressable/uri.rb:874:in `scheme='
Addressable::URI::InvalidURIError (Invalid scheme format: Corvallis, Or. )
```