### PR TITLE
custom visibility options for depositors on GTD forms

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -132,4 +132,8 @@ module ApplicationHelper
     facet_values = ScholarsArchive::AllFacetValuesService.new.call(facet_object, controller)
     (facet_values.length.to_f / pagination_object.limit.to_f).ceil
   end
+
+  def option_visible_to_depositor?(model, user)
+    user.admin? == false && model.class == GraduateThesisOrDissertation ? false : true
+  end
 end

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -16,6 +16,7 @@
             </div>
           </label>
         </li>
+        <% if option_visible_to_depositor?(f.object.model, current_user) %>
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
@@ -23,6 +24,7 @@
             <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
           </label>
         </li>
+        <% end %>
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
@@ -63,6 +65,8 @@
             </div>
           </label>
         </li>
+
+        <% if option_visible_to_depositor?(f.object.model, current_user) %>
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
@@ -70,6 +74,7 @@
             <%= t('hyrax.visibility.restricted.note_html') %>
           </label>
         </li>
+        <% end %>
       </ul>
     </fieldset>
 <% end %>

--- a/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
@@ -7,11 +7,7 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
   let(:form) do
     Hyrax::DefaultForm.new(work, nil, controller)
   end
-  let(:work) do
-    Default.new do |w|
-      w.title = ['test']
-    end
-  end
+  let(:work) { Default.new }
   let(:page) do
     view.simple_form_for form do |f|
       render 'hyrax/base/form_progress', f: f
@@ -58,11 +54,7 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
     let(:form) do
       Hyrax::GraduateThesisOrDissertationForm.new(work, nil, controller)
     end
-    let(:work) do
-      GraduateThesisOrDissertation.new do |w|
-        w.title = ['test']
-      end
-    end
+    let(:work) { GraduateThesisOrDissertation.new }
     let(:model_name) { 'graduate_thesis_or_dissertation' }
 
     context 'when for admin users' do
@@ -92,11 +84,7 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
     let(:form) do
       Hyrax::GraduateProjectForm.new(work, nil, controller)
     end
-    let(:work) do
-      GraduateProject.new do |w|
-        w.title = ['test']
-      end
-    end
+    let(:work) { GraduateProject.new }
     let(:model_name) { 'graduate_project' }
 
     context 'when admin users' do
@@ -126,11 +114,7 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
     let(:form) do
       Hyrax::ArticleForm.new(work, nil, controller)
     end
-    let(:work) do
-      Article.new do |w|
-        w.title = ['test']
-      end
-    end
+    let(:work) { Article.new }
     let(:model_name) { 'article' }
 
     context 'when admin users' do

--- a/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
   let(:user) do
     User.new(username: 'admin', email: 'test@example.com', guest: false)
@@ -38,18 +36,10 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
         allow(user).to receive(:admin?).and_return(true)
       end
 
-      it 'shows public visibility option' do
-        expect(page).to have_selector(open_option_id)
-      end
-      it 'shows embargo visibility option' do
-        expect(page).to have_selector(embargo_option_id)
-      end
-      it 'does show private visibility option' do
-        expect(page).to have_selector(restricted_option_id)
-      end
-      it 'does show institution visibility option' do
-        expect(page).to have_selector(authenticated_option_id)
-      end
+      it { expect(page).to have_selector(open_option_id) }
+      it { expect(page).to have_selector(embargo_option_id) }
+      it { expect(page).to have_selector(restricted_option_id) }
+      it { expect(page).to have_selector(authenticated_option_id) }
     end
 
     context 'when non admin users' do
@@ -57,18 +47,10 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
         allow(user).to receive(:admin?).and_return(false)
       end
 
-      it 'shows public visibility option' do
-        expect(page).to have_selector(open_option_id)
-      end
-      it 'shows embargo visibility option' do
-        expect(page).to have_selector(embargo_option_id)
-      end
-      it 'does show private visibility option' do
-        expect(page).to have_selector(restricted_option_id)
-      end
-      it 'does show institution visibility option' do
-        expect(page).to have_selector(authenticated_option_id)
-      end
+      it { expect(page).to have_selector(open_option_id) }
+      it { expect(page).to have_selector(embargo_option_id) }
+      it { expect(page).to have_selector(restricted_option_id) }
+      it { expect(page).to have_selector(authenticated_option_id) }
     end
   end
 
@@ -88,18 +70,10 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
         allow(user).to receive(:admin?).and_return(true)
       end
 
-      it 'shows public visibility option' do
-        expect(page).to have_selector(open_option_id)
-      end
-      it 'shows embargo visibility option' do
-        expect(page).to have_selector(embargo_option_id)
-      end
-      it 'does not show private visibility option' do
-        expect(page).to have_selector(restricted_option_id)
-      end
-      it 'does not show institution visibility option' do
-        expect(page).to have_selector(authenticated_option_id)
-      end
+      it { expect(page).to have_selector(open_option_id) }
+      it { expect(page).to have_selector(embargo_option_id) }
+      it { expect(page).to have_selector(restricted_option_id) }
+      it { expect(page).to have_selector(authenticated_option_id) }
     end
 
     context 'when non-admin users' do
@@ -107,18 +81,10 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
         allow(user).to receive(:admin?).and_return(false)
       end
 
-      it 'shows public visibility option' do
-        expect(page).to have_selector(open_option_id)
-      end
-      it 'shows embargo visibility option' do
-        expect(page).to have_selector(embargo_option_id)
-      end
-      it 'does not show private visibility option' do
-        expect(page).not_to have_selector(restricted_option_id)
-      end
-      it 'does not show institution visibility option' do
-        expect(page).not_to have_selector(authenticated_option_id)
-      end
+      it { expect(page).to have_selector(open_option_id) }
+      it { expect(page).to have_selector(embargo_option_id) }
+      it { expect(page).not_to have_selector(restricted_option_id) }
+      it { expect(page).not_to have_selector(authenticated_option_id) }
     end
   end
 
@@ -138,18 +104,10 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
         allow(user).to receive(:admin?).and_return(true)
       end
 
-      it 'shows public visibility option' do
-        expect(page).to have_selector(open_option_id)
-      end
-      it 'shows embargo visibility option' do
-        expect(page).to have_selector(embargo_option_id)
-      end
-      it 'does show private visibility option' do
-        expect(page).to have_selector(restricted_option_id)
-      end
-      it 'does show institution visibility option' do
-        expect(page).to have_selector(authenticated_option_id)
-      end
+      it { expect(page).to have_selector(open_option_id) }
+      it { expect(page).to have_selector(embargo_option_id) }
+      it { expect(page).to have_selector(restricted_option_id) }
+      it { expect(page).to have_selector(authenticated_option_id) }
     end
 
     context 'when non-admin users' do
@@ -157,18 +115,10 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
         allow(user).to receive(:admin?).and_return(false)
       end
 
-      it 'shows public visibility option' do
-        expect(page).to have_selector(open_option_id)
-      end
-      it 'shows embargo visibility option' do
-        expect(page).to have_selector(embargo_option_id)
-      end
-      it 'does show private visibility option' do
-        expect(page).to have_selector(restricted_option_id)
-      end
-      it 'does show institution visibility option' do
-        expect(page).to have_selector(authenticated_option_id)
-      end
+      it { expect(page).to have_selector(open_option_id) }
+      it { expect(page).to have_selector(embargo_option_id) }
+      it { expect(page).to have_selector(restricted_option_id) }
+      it { expect(page).to have_selector(authenticated_option_id) }
     end
   end
 
@@ -188,18 +138,10 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
         allow(user).to receive(:admin?).and_return(true)
       end
 
-      it 'shows public visibility option' do
-        expect(page).to have_selector(open_option_id)
-      end
-      it 'shows embargo visibility option' do
-        expect(page).to have_selector(embargo_option_id)
-      end
-      it 'does show private visibility option' do
-        expect(page).to have_selector(restricted_option_id)
-      end
-      it 'does show institution visibility option' do
-        expect(page).to have_selector(authenticated_option_id)
-      end
+      it { expect(page).to have_selector(open_option_id) }
+      it { expect(page).to have_selector(embargo_option_id) }
+      it { expect(page).to have_selector(restricted_option_id) }
+      it { expect(page).to have_selector(authenticated_option_id) }
     end
 
     context 'when non admin users' do
@@ -207,18 +149,10 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
         allow(user).to receive(:admin?).and_return(false)
       end
 
-      it 'shows public visibility option' do
-        expect(page).to have_selector(open_option_id)
-      end
-      it 'shows embargo visibility option' do
-        expect(page).to have_selector(embargo_option_id)
-      end
-      it 'does show private visibility option' do
-        expect(page).to have_selector(restricted_option_id)
-      end
-      it 'does show institution visibility option' do
-        expect(page).to have_selector(authenticated_option_id)
-      end
+      it { expect(page).to have_selector(open_option_id) }
+      it { expect(page).to have_selector(embargo_option_id) }
+      it { expect(page).to have_selector(restricted_option_id) }
+      it { expect(page).to have_selector(authenticated_option_id) }
     end
   end
 end

--- a/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
+  let(:user) do
+    User.new(username: 'admin', email: 'test@example.com', guest: false)
+  end
+  let(:form) do
+    Hyrax::DefaultForm.new(work, nil, controller)
+  end
+  let(:work) do
+    Default.new do |w|
+      w.title = ['test']
+    end
+  end
+  let(:page) do
+    view.simple_form_for form do |f|
+      render 'hyrax/base/form_progress', f: f
+    end
+    Capybara::Node::Simple.new(rendered)
+  end
+  let(:model_name) { 'default' }
+  let(:open_option_id) { "##{model_name}_visibility_open" }
+  let(:embargo_option_id) { "##{model_name}_visibility_embargo" }
+  let(:restricted_option_id) { "##{model_name}_visibility_restricted" }
+  let(:authenticated_option_id) { "##{model_name}_visibility_authenticated" }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(work).to receive(:visibility).and_return('open')
+    assign(:form, form)
+  end
+
+  context 'with visibility options on defaults' do
+    context 'when admin users' do
+      before do
+        allow(user).to receive(:admin?).and_return(true)
+      end
+
+      it 'shows public visibility option' do
+        expect(page).to have_selector(open_option_id)
+      end
+      it 'shows embargo visibility option' do
+        expect(page).to have_selector(embargo_option_id)
+      end
+      it 'does show private visibility option' do
+        expect(page).to have_selector(restricted_option_id)
+      end
+      it 'does show institution visibility option' do
+        expect(page).to have_selector(authenticated_option_id)
+      end
+    end
+
+    context 'when non admin users' do
+      before do
+        allow(user).to receive(:admin?).and_return(false)
+      end
+
+      it 'shows public visibility option' do
+        expect(page).to have_selector(open_option_id)
+      end
+      it 'shows embargo visibility option' do
+        expect(page).to have_selector(embargo_option_id)
+      end
+      it 'does show private visibility option' do
+        expect(page).to have_selector(restricted_option_id)
+      end
+      it 'does show institution visibility option' do
+        expect(page).to have_selector(authenticated_option_id)
+      end
+    end
+  end
+
+  context 'with visibility options on graduate_thesis_or_dissertations' do
+    let(:form) do
+      Hyrax::GraduateThesisOrDissertationForm.new(work, nil, controller)
+    end
+    let(:work) do
+      GraduateThesisOrDissertation.new do |w|
+        w.title = ['test']
+      end
+    end
+    let(:model_name) { 'graduate_thesis_or_dissertation' }
+
+    context 'when for admin users' do
+      before do
+        allow(user).to receive(:admin?).and_return(true)
+      end
+
+      it 'shows public visibility option' do
+        expect(page).to have_selector(open_option_id)
+      end
+      it 'shows embargo visibility option' do
+        expect(page).to have_selector(embargo_option_id)
+      end
+      it 'does not show private visibility option' do
+        expect(page).to have_selector(restricted_option_id)
+      end
+      it 'does not show institution visibility option' do
+        expect(page).to have_selector(authenticated_option_id)
+      end
+    end
+
+    context 'when non-admin users' do
+      before do
+        allow(user).to receive(:admin?).and_return(false)
+      end
+
+      it 'shows public visibility option' do
+        expect(page).to have_selector(open_option_id)
+      end
+      it 'shows embargo visibility option' do
+        expect(page).to have_selector(embargo_option_id)
+      end
+      it 'does not show private visibility option' do
+        expect(page).not_to have_selector(restricted_option_id)
+      end
+      it 'does not show institution visibility option' do
+        expect(page).not_to have_selector(authenticated_option_id)
+      end
+    end
+  end
+
+  context 'with visibility options on graduate_projects' do
+    let(:form) do
+      Hyrax::GraduateProjectForm.new(work, nil, controller)
+    end
+    let(:work) do
+      GraduateProject.new do |w|
+        w.title = ['test']
+      end
+    end
+    let(:model_name) { 'graduate_project' }
+
+    context 'when admin users' do
+      before do
+        allow(user).to receive(:admin?).and_return(true)
+      end
+
+      it 'shows public visibility option' do
+        expect(page).to have_selector(open_option_id)
+      end
+      it 'shows embargo visibility option' do
+        expect(page).to have_selector(embargo_option_id)
+      end
+      it 'does show private visibility option' do
+        expect(page).to have_selector(restricted_option_id)
+      end
+      it 'does show institution visibility option' do
+        expect(page).to have_selector(authenticated_option_id)
+      end
+    end
+
+    context 'when non-admin users' do
+      before do
+        allow(user).to receive(:admin?).and_return(false)
+      end
+
+      it 'shows public visibility option' do
+        expect(page).to have_selector(open_option_id)
+      end
+      it 'shows embargo visibility option' do
+        expect(page).to have_selector(embargo_option_id)
+      end
+      it 'does show private visibility option' do
+        expect(page).to have_selector(restricted_option_id)
+      end
+      it 'does show institution visibility option' do
+        expect(page).to have_selector(authenticated_option_id)
+      end
+    end
+  end
+
+  context 'with visibility options for non admin users on articles' do
+    let(:form) do
+      Hyrax::ArticleForm.new(work, nil, controller)
+    end
+    let(:work) do
+      Article.new do |w|
+        w.title = ['test']
+      end
+    end
+    let(:model_name) { 'article' }
+
+    context 'when admin users' do
+      before do
+        allow(user).to receive(:admin?).and_return(true)
+      end
+
+      it 'shows public visibility option' do
+        expect(page).to have_selector(open_option_id)
+      end
+      it 'shows embargo visibility option' do
+        expect(page).to have_selector(embargo_option_id)
+      end
+      it 'does show private visibility option' do
+        expect(page).to have_selector(restricted_option_id)
+      end
+      it 'does show institution visibility option' do
+        expect(page).to have_selector(authenticated_option_id)
+      end
+    end
+
+    context 'when non admin users' do
+      before do
+        allow(user).to receive(:admin?).and_return(false)
+      end
+
+      it 'shows public visibility option' do
+        expect(page).to have_selector(open_option_id)
+      end
+      it 'shows embargo visibility option' do
+        expect(page).to have_selector(embargo_option_id)
+      end
+      it 'does show private visibility option' do
+        expect(page).to have_selector(restricted_option_id)
+      end
+      it 'does show institution visibility option' do
+        expect(page).to have_selector(authenticated_option_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes #1491 
It hides the `Oregon State University` and `Private` option under `Visibility` for the GraduateThesisOrDissertation model and non admin users only:
![image](https://user-images.githubusercontent.com/3486120/56609370-c170cf00-65c1-11e9-8a07-5d468ccaa611.png)
