### PR TITLE
hotfix for LDP conflict fix

### DIFF
--- a/config/initializers/noid_rails.rb
+++ b/config/initializers/noid_rails.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This is a fix for a bug in Hyrax where under certain circumstances the minter
+# stops issuing new IDs, preventing new objects from being created.
+# See https://github.com/samvera/hyrax/issues/3128 for more details.
+::Noid::Rails.config.identifier_in_use = lambda do |id|
+  ActiveFedora::Base.exists?(id) || ActiveFedora::Base.gone?(id)
+end


### PR DESCRIPTION
This is a hot fix to merge in a fix that's also provided upstream (https://github.com/MPLSFedResearch/cypripedium/pull/304/files) to cause AF to not get caught up with an LDP conflict