### PR TITLE
Google scholar citation updates

### DIFF
--- a/app/helpers/google_scholar_helper.rb
+++ b/app/helpers/google_scholar_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Google Scholar view helper
+module GoogleScholarHelper
+  def citation_publication_date(value)
+    ScholarsArchive::GoogleScholarCitationService.call(value)
+  end
+end

--- a/app/services/scholars_archive/google_scholar_citation_service.rb
+++ b/app/services/scholars_archive/google_scholar_citation_service.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module ScholarsArchive
+  # Class to handle the expected format for citation publication dates as
+  # required in the indexing guidelines for configuring meta-tags:
+  # https://scholar.google.com/intl/en/scholar/inclusion.html#indexing
+  class GoogleScholarCitationService
+    attr_reader :input_date
+
+    def self.call(input_date)
+      new(input_date).call
+    end
+
+    def call
+      format_date
+    end
+
+    private
+
+    def initialize(input_date)
+      @edtf_value = edtf_date(input_date)
+    end
+
+    def edtf_date(date)
+      edtf_val = Date.edtf(date)
+      if edtf_val.blank? && date.present?
+        # date_uploaded usually comes in the form m/d/Y unlike edtf that comes in the form Y-m-d
+        custom_date = Date.strptime(date, '%m/%d/%Y')
+        edtf_val = Date.edtf(custom_date.to_s)
+      end
+      edtf_val
+    rescue StandardError => e
+      Rails.logger.warn "GoogleScholarCitationService #{e.message}"
+      nil
+    end
+
+    def format_date
+      if @edtf_value.instance_of? EDTF::Interval
+        @edtf_value.to_s
+      elsif @edtf_value.present?
+        date_from_edtf(@edtf_value)
+      else
+        @edtf_value.to_s
+      end
+    end
+
+    def date_from_edtf(date)
+      case date
+      when year_precision
+        date.year.to_s
+      when month_precision
+        date.try(:strftime, '%Y/%m')
+      when day_precision
+        date.try(:strftime, '%Y/%m/%d')
+      else
+        date.to_s
+      end
+    end
+
+    def month_precision
+      proc(&:month_precision?)
+    end
+
+    def day_precision
+      proc(&:day_precision?)
+    end
+
+    def year_precision
+      proc(&:year_precision?)
+    end
+  end
+end

--- a/app/services/scholars_archive/google_scholar_citation_service.rb
+++ b/app/services/scholars_archive/google_scholar_citation_service.rb
@@ -11,6 +11,16 @@ module ScholarsArchive
       new(input_date).format_date
     end
 
+    def format_date
+      if @edtf_value.instance_of? EDTF::Interval
+        @edtf_value.to_s
+      elsif @edtf_value.present?
+        date_from_edtf(@edtf_value)
+      else
+        @edtf_value.to_s
+      end
+    end
+
     private
 
     def initialize(input_date)
@@ -28,16 +38,6 @@ module ScholarsArchive
     rescue StandardError => e
       Rails.logger.warn "GoogleScholarCitationService #{e.message}"
       nil
-    end
-
-    def format_date
-      if @edtf_value.instance_of? EDTF::Interval
-        @edtf_value.to_s
-      elsif @edtf_value.present?
-        date_from_edtf(@edtf_value)
-      else
-        @edtf_value.to_s
-      end
     end
 
     def date_from_edtf(date)

--- a/app/services/scholars_archive/google_scholar_citation_service.rb
+++ b/app/services/scholars_archive/google_scholar_citation_service.rb
@@ -8,11 +8,7 @@ module ScholarsArchive
     attr_reader :input_date
 
     def self.call(input_date)
-      new(input_date).call
-    end
-
-    def call
-      format_date
+      new(input_date).format_date
     end
 
     private

--- a/app/views/shared/_citations.html.erb
+++ b/app/views/shared/_citations.html.erb
@@ -20,15 +20,16 @@
   <% @presenter.creator.each do |creator| %>
     <meta name="citation_author" content="<%= creator %>"/>
   <% end %>
-
   <% if @presenter.date_created.present? %>
     <meta name="citation_publication_date" content="<%= @presenter.date_created.first %>"/>
   <% elsif @presenter.date_issued.present? %>
     <meta name="citation_publication_date" content="<%= @presenter.date_issued.first %>"/>
   <% elsif @presenter.date_accepted.present? %>
     <meta name="citation_publication_date" content="<%= @presenter.date_accepted.first %>"/>
-  <% else %>
-    <meta name="citation_publication_date" content="<%= @presenter.date_uploaded %>"/>
+  <% elsif @presenter.date_uploaded.present? %>
+    <% if citation_publication_date(@presenter.date_uploaded.to_s).present? %>
+      <meta name="citation_publication_date" content="<%= citation_publication_date(@presenter.date_uploaded.to_s) %>"/>
+    <% end %>
   <% end %>
 
   <% if @presenter.representative_id %>
@@ -46,16 +47,14 @@
   <% end %>
 
   <% if ['ConferenceProceedingsOrJournal', 'Article'].include? @presenter.model_name.name %>
-    <meta name="citation_journal_title" content="<%= @presenter.has_journal.first if @presenter.has_journal.present? %>"/>
-    <meta name="citation_volume" content="<%= @presenter.has_volume.first if @presenter.has_volume.present? %>"/>
-    <meta name="citation_issue" content="<%= @presenter.has_number.first if @presenter.has_number.present? %>"/>
-  <% else %>
-    <meta name="citation_journal_title" content=""/>
-    <meta name="citation_volume" content=""/>
-    <meta name="citation_issue" content=""/>
+    <% if @presenter.has_journal.present? %>
+      <meta name="citation_journal_title" content="<%= @presenter.has_journal.first %>"/>
+    <% end %>
+    <% if @presenter.has_volume.present? %>
+      <meta name="citation_volume" content="<%= @presenter.has_volume.first %>"/>
+    <% end %>
+    <% if @presenter.has_number.present?  %>
+      <meta name="citation_issue" content="<%= @presenter.has_number.first %>"/>
+    <% end %>
   <% end %>
-
-  <!-- Hyrax does not yet support these metadata -->
-  <meta name="citation_firstpage" content=""/>
-  <meta name="citation_lastpage" content=""/>
 <% end %>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -10,3 +10,8 @@ Crawl-delay: 8
 Disallow: /catalog
 Disallow: /files/*/stats
 Disallow: /oai
+
+User-agent: Googlebot
+Allow: /catalog
+Disallow: /files/*/stats
+Disallow: /oai

--- a/spec/services/scholars_archive/google_scholar_citation_service_spec.rb
+++ b/spec/services/scholars_archive/google_scholar_citation_service_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_helper'
+describe ScholarsArchive::GoogleScholarCitationService do
+  let(:service) { described_class }
+
+  describe '#call' do
+    context 'when formatting citation publication dates' do
+      it 'returns a date in Y/m/d format when given in Y-m-d' do
+        expect(service.call('2019-12-20')).to eq '2019/12/20'
+      end
+      it 'returns back an interval when given in Y-m-d/Y-m-d' do
+        expect(service.call('2019-12-20/2019-12-21')).to eq '2019-12-20/2019-12-21'
+      end
+      it 'returns a from date in Y/m/d format when given in m/d/y' do
+        expect(service.call('12/20/2019')).to eq '2019/12/20'
+      end
+      it 'returns empty string when given invalid date' do
+        expect(service.call('invalid')).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/osulp/Scholars-Archive/issues/1916

Google Scholar requires citation publication date meta tags to be in the format `Y/m/d` according to the indexing guidelines https://scholar.google.com/intl/en/scholar/inclusion.html#indexing.

- This update adds a `citation_publication_date` helper to format dates from the presenter to follow the guidelines. This one is used to format `date_uploaded`, which comes in the form `m/d/Y` and is a fallback when `date_created`, `date_issued`, and `date_accepted` are not available.
- It also skips empty or unsupported meta-tags like `citation_firstpage` and `citation_lastpage`.
- Robots.txt update: allow `catalog` to `Googlebot`

Notes/findings:

- [x] 1. Find out if Google Scholar accepts `Y/m`- Update: Yes
- [x] 2. Find out if Google Scholar accepts date intervals like `Y/m/d-Y/m/d` - Update: No
- [x] 3. If (2) is not possible, check with metadata group and see if we can cleanup publication date when given a date interval for `date_created`, `date_issued`, and `date_accepted` (these fields are used in `citation_publication_date` meta tag for Google Scholar).