### PR TITLE
add rescue err to track_download

### DIFF
--- a/app/controllers/concerns/scholars_archive/download_analytics_behavior.rb
+++ b/app/controllers/concerns/scholars_archive/download_analytics_behavior.rb
@@ -13,21 +13,26 @@ module ScholarsArchive
           # Staccato works with Google Analytics v1 api:
           # https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
           # Staccato on Github: https://github.com/tpitale/staccato
-          tracker = Staccato.tracker(Hyrax.config.google_analytics_id)
-          tracker.event(category: 'Files',
-                        action: 'Downloaded',
-                        label: params[:id],
-                        linkid: request.url,
-                        user_agent: request.headers['User-Agent'],
-                        user_ip: request.remote_ip)
-          # Setting the title to be the download id provides an easy way to group
-          # and count on GA
-          tracker.pageview(path: request.url,
-                           hostname: request.server_name,
-                           title: params[:id],
-                           user_agent: request.headers['User-Agent'],
-                           user_ip: request.remote_ip)
-          tracker.track
+          begin
+            tracker = Staccato.tracker(Hyrax.config.google_analytics_id)
+            tracker.event(category: 'Files',
+                          action: 'Downloaded',
+                          label: params[:id],
+                          linkid: request.url,
+                          user_agent: request.headers['User-Agent'],
+                          user_ip: request.remote_ip)
+            # Setting the title to be the download id provides an easy way to group
+            # and count on GA
+            tracker.pageview(path: request.url,
+                             hostname: request.server_name,
+                             title: params[:id],
+                             user_agent: request.headers['User-Agent'],
+                             user_ip: request.remote_ip)
+            tracker.track
+          rescue StandardError => e
+            Rails.logger.error "Staccato Error: #{e.message} : #{e.backtrace}"
+            return nil
+          end
         end
       end
     end

--- a/spec/controllers/scholars_archive/downloads_controller_spec.rb
+++ b/spec/controllers/scholars_archive/downloads_controller_spec.rb
@@ -12,4 +12,20 @@ RSpec.describe ScholarsArchive::DownloadsController, type: :controller do
     expect(controller).to respond_to(:track_download)
     expect(controller.track_download).to be_a_kind_of Net::HTTPOK
   end
+
+  context 'when rescuing errors from Staccato' do
+    let(:error) { StandardError }
+
+    before do
+      allow(Staccato).to receive(:tracker).and_raise(error)
+      stub_request(:post, 'http://www.google-analytics.com/collect').to_return(status: 200, body: '', headers: {})
+    end
+
+    it 'responds to track_download' do
+      expect(controller).to respond_to(:track_download)
+    end
+    it 'rescues errors from Staccato' do
+      expect(controller.track_download).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Adds a rescue to Staccato.tracker call in Downloads controller behavior and sends error message and trace to the logs.


