### PR TITLE
allow to_value to be blank and clear all values

### DIFF
--- a/lib/tasks/bulk_update_csv.rake
+++ b/lib/tasks/bulk_update_csv.rake
@@ -85,9 +85,8 @@ end
 
 def overwrite_multivalue_row(logger, work, row, property)
   to_value = row[:to]&.to_s
-  return work if to_value.blank?
-
-  if ordered_property? row[:property]
+  
+  if ordered_property? row[:property] && to_value.present?
     handle_ordered_property(work, 'overwrite_ordered_property_value', to_value, row)
   else
     work[row[:property]] = to_value.blank? ? nil : [to_value&.split('|')].flatten


### PR DESCRIPTION
- when given `*` under `from` and an empty cell under `to`, clear all values for given `property`
- this update applies to multi-value properties both ordered and unordered
- if given an unordered property (i.e. `additional_information`) check if value under `to` is present before proceeding with the update