### PR TITLE
Add CSS override to remove blur on masthead image.

### DIFF
--- a/app/assets/stylesheets/osu.scss
+++ b/app/assets/stylesheets/osu.scss
@@ -22,6 +22,10 @@
 
 .image-masthead .background-container {
   background-image: image-url("SA-Mast-Head.png") !important;
+
+  // Override Hyrax masthead blur setting
+  -webkit-filter: blur(0px) !important;
+  filter: blur(0px) !important;
 }
 
 #masthead {


### PR DESCRIPTION
This removes the top line on the masthead image, which was coming from the blur function. Since there's no text on top of the image, the blur isn't necessary.