### PR TITLE
Move Advisor to Default work type

### DIFF
--- a/app/forms/hyrax/forms/batch_upload_form.rb
+++ b/app/forms/hyrax/forms/batch_upload_form.rb
@@ -28,7 +28,7 @@ module Hyrax
 
       # On the batch upload, title is set per-file.
       def primary_terms
-        %i[alt_title nested_ordered_creator contributor nested_ordered_abstract license doi identifier bibliographic_citation academic_affiliation other_affiliation in_series subject tableofcontents rights_statement] | super - %i[title nested_ordered_title resource_type]
+        %i[alt_title nested_ordered_creator contributor contributor_advisor nested_ordered_abstract license doi identifier bibliographic_citation academic_affiliation other_affiliation in_series subject tableofcontents rights_statement] | super - %i[title nested_ordered_title resource_type]
       end
 
       # # On the batch upload, title is set per-file.

--- a/app/forms/scholars_archive/article_work_form_behavior.rb
+++ b/app/forms/scholars_archive/article_work_form_behavior.rb
@@ -8,7 +8,7 @@ module ScholarsArchive
       self.terms += %i[resource_type editor has_volume has_number conference_location conference_name conference_section has_journal is_referenced_by web_of_science_uid]
 
       def primary_terms
-        %i[nested_ordered_title alt_title nested_ordered_creator nested_ordered_contributor nested_ordered_abstract license resource_type doi dates_section bibliographic_citation is_referenced_by has_journal has_volume has_number conference_name conference_section conference_location editor academic_affiliation other_affiliation in_series subject tableofcontents rights_statement] | super - %i[degree_level degree_name degree_field]
+        %i[nested_ordered_title alt_title nested_ordered_creator nested_ordered_contributor nested_ordered_abstract license resource_type doi dates_section bibliographic_citation is_referenced_by has_journal has_volume has_number conference_name conference_section conference_location editor academic_affiliation other_affiliation in_series subject tableofcontents rights_statement] | super - %i[degree_level degree_name degree_field contributor_advisor]
       end
 
       def secondary_terms

--- a/app/forms/scholars_archive/default_work_form_behavior.rb
+++ b/app/forms/scholars_archive/default_work_form_behavior.rb
@@ -17,14 +17,14 @@ module ScholarsArchive
       attr_accessor :degree_field_other
       attr_accessor :degree_name_other
 
-      self.terms += %i[nested_related_items nested_ordered_creator nested_ordered_title nested_ordered_abstract nested_ordered_additional_information nested_ordered_contributor date_uploaded date_modified doi other_affiliation academic_affiliation alt_title license resource_type date_available date_copyright date_issued date_collected date_valid date_reviewed date_accepted degree_level degree_name degree_field replaces nested_geo hydrologic_unit_code funding_body funding_statement in_series tableofcontents bibliographic_citation peerreviewed digitization_spec file_extent file_format dspace_community dspace_collection isbn issn embargo_reason conference_name conference_section conference_location]
+      self.terms += %i[nested_related_items nested_ordered_creator nested_ordered_title nested_ordered_abstract nested_ordered_additional_information nested_ordered_contributor date_uploaded date_modified doi other_affiliation academic_affiliation alt_title license resource_type date_available date_copyright date_issued date_collected date_valid date_reviewed date_accepted degree_level degree_name degree_field replaces nested_geo hydrologic_unit_code funding_body funding_statement in_series tableofcontents bibliographic_citation peerreviewed digitization_spec file_extent file_format dspace_community dspace_collection isbn issn embargo_reason conference_name conference_section conference_location contributor_advisor]
 
       self.terms -= %i[creator title]
       self.required_fields += %i[resource_type nested_ordered_creator nested_ordered_title]
       self.required_fields -= %i[keyword creator title contributor]
 
       def primary_terms
-        %i[nested_ordered_title alt_title nested_ordered_creator nested_ordered_contributor nested_ordered_abstract license resource_type doi dates_section degree_level degree_name degree_field bibliographic_citation academic_affiliation other_affiliation in_series subject tableofcontents rights_statement] | super
+        %i[nested_ordered_title alt_title nested_ordered_creator nested_ordered_contributor contributor_advisor nested_ordered_abstract license resource_type doi dates_section degree_level degree_name degree_field bibliographic_citation academic_affiliation other_affiliation in_series subject tableofcontents rights_statement] | super
       end
 
       def secondary_terms

--- a/app/forms/scholars_archive/etd_work_form_behavior.rb
+++ b/app/forms/scholars_archive/etd_work_form_behavior.rb
@@ -8,7 +8,7 @@ module ScholarsArchive
       include ScholarsArchive::DefaultWorkFormBehavior
       attr_accessor :degree_grantors_other
 
-      self.terms += %i[degree_grantors contributor_advisor contributor_committeemember graduation_year degree_discipline]
+      self.terms += %i[degree_grantors contributor_committeemember graduation_year degree_discipline]
       self.required_fields += %i[degree_level degree_name degree_field degree_grantors graduation_year]
 
       def primary_terms

--- a/app/forms/scholars_archive/oer_work_form_behavior.rb
+++ b/app/forms/scholars_archive/oer_work_form_behavior.rb
@@ -8,7 +8,7 @@ module ScholarsArchive
       self.terms += %i[resource_type is_based_on_url interactivity_type learning_resource_type typical_age_range time_required duration]
 
       def primary_terms
-        %i[nested_ordered_title alt_title nested_ordered_creator nested_ordered_contributor nested_ordered_abstract license resource_type doi dates_section time_required typical_age_range learning_resource_type interactivity_type is_based_on_url bibliographic_citation academic_affiliation other_affiliation in_series subject tableofcontents rights_statement] | super - %i[degree_level degree_name degree_field]
+        %i[nested_ordered_title alt_title nested_ordered_creator nested_ordered_contributor nested_ordered_abstract license resource_type doi dates_section time_required typical_age_range learning_resource_type interactivity_type is_based_on_url bibliographic_citation academic_affiliation other_affiliation in_series subject tableofcontents rights_statement] | super - %i[degree_level degree_name degree_field contributor_advisor]
       end
 
       def secondary_terms

--- a/app/indexers/default_work_indexer.rb
+++ b/app/indexers/default_work_indexer.rb
@@ -3,7 +3,7 @@
 # indexes default metadata
 class DefaultWorkIndexer < Hyrax::WorkIndexer
   class_attribute :stored_and_facetable_fields
-  self.stored_and_facetable_fields = %i[doi rights_statement rights_statement_label abstract alt_title license license_label language_label based_near based_near_linked resource_type date_available date_copyright date_issued date_collected date_valid date_reviewed date_accepted degree_level degree_name degree_field replaces hydrologic_unit_code funding_body funding_statement in_series tableofcontents bibliographic_citation peerreviewed additional_information digitization_spec file_extent file_format dspace_community dspace_collection itemtype nested_geo peerreviewed_label conference_name conference_section conference_location ]
+  self.stored_and_facetable_fields = %i[doi rights_statement rights_statement_label abstract alt_title license license_label language_label based_near based_near_linked resource_type date_available date_copyright date_issued date_collected date_valid date_reviewed date_accepted degree_level degree_name degree_field replaces hydrologic_unit_code funding_body funding_statement in_series tableofcontents bibliographic_citation peerreviewed additional_information digitization_spec file_extent file_format dspace_community dspace_collection itemtype nested_geo peerreviewed_label conference_name conference_section conference_location contributor_advisor]
   # This indexes the default metadata. You can remove it if you want to
   # provide your own metadata and indexing.
   include Hyrax::IndexesBasicMetadata

--- a/app/indexers/etd_indexer.rb
+++ b/app/indexers/etd_indexer.rb
@@ -2,7 +2,7 @@
 
 # indexes etd metadata
 class EtdIndexer < DefaultWorkIndexer
-  self.stored_and_facetable_fields += %i[contributor_advisor contributor_committeemember degree_discipline degree_grantors graduation_year]
+  self.stored_and_facetable_fields += %i[contributor_committeemember degree_discipline degree_grantors graduation_year]
 
   # Fetch remote labels for based_near. You can remove this if you don't want
   # this behavior

--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -71,6 +71,10 @@ module ScholarsArchive
         index.as :stored_searchable
       end
 
+      property :contributor_advisor, predicate: ::RDF::Vocab::MARCRelators.ths do |index|
+        index.as :stored_searchable, :facetable
+      end
+
       property :creator, predicate: ::RDF::Vocab::DC11.creator do |index|
         index.as :stored_searchable, :facetable
       end

--- a/app/models/concerns/scholars_archive/etd_metadata.rb
+++ b/app/models/concerns/scholars_archive/etd_metadata.rb
@@ -9,10 +9,6 @@ module ScholarsArchive
     #   https://docs.google.com/spreadsheets/d/1koKjV7bjn7v4r5a3gsowEimljHiAwbwuOgjHe7FEtuw/edit?usp=sharing
 
     included do
-      property :contributor_advisor, predicate: ::RDF::Vocab::MARCRelators.ths do |index|
-        index.as :stored_searchable, :facetable
-      end
-
       property :contributor_committeemember, predicate: ::RDF::Vocab::MARCRelators.dgs do |index|
         index.as :stored_searchable, :facetable
       end

--- a/app/presenters/concerns/scholars_archive/default_presenter_behavior.rb
+++ b/app/presenters/concerns/scholars_archive/default_presenter_behavior.rb
@@ -13,6 +13,7 @@ module ScholarsArchive
                :conference_name,
                :conference_section,
                :conference_location,
+               :contributor_advisor,
                :date_accepted,
                :date_available,
                :date_collected,

--- a/app/presenters/concerns/scholars_archive/etd_presenter_behavior.rb
+++ b/app/presenters/concerns/scholars_archive/etd_presenter_behavior.rb
@@ -5,8 +5,7 @@ module ScholarsArchive
   module EtdPresenterBehavior
     extend ActiveSupport::Concern
     included do
-      delegate :contributor_advisor,
-               :contributor_committeemember,
+      delegate :contributor_committeemember,
                :degree_discipline,
                :degree_field,
                :degree_field_label,

--- a/spec/forms/hyrax/default_form_spec.rb
+++ b/spec/forms/hyrax/default_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hyrax::DefaultForm do
   end
 
   it 'responds to terms with the proper list of terms' do
-    expect(described_class.terms).to include *%i[isbn issn doi alt_title nested_ordered_abstract license based_near resource_type date_available date_copyright date_issued date_collected date_reviewed date_valid date_accepted replaces hydrologic_unit_code funding_body funding_statement in_series tableofcontents bibliographic_citation peerreviewed nested_ordered_additional_information digitization_spec file_extent file_format dspace_community dspace_collection conference_location conference_name conference_section]
+    expect(described_class.terms).to include *%i[isbn issn doi alt_title nested_ordered_abstract license based_near resource_type date_available date_copyright date_issued date_collected date_reviewed date_valid date_accepted replaces hydrologic_unit_code funding_body funding_statement in_series tableofcontents bibliographic_citation peerreviewed nested_ordered_additional_information digitization_spec file_extent file_format dspace_community dspace_collection conference_location conference_name conference_section contributor_advisor]
   end
 
   it 'has the proper required fields' do
@@ -23,7 +23,7 @@ RSpec.describe Hyrax::DefaultForm do
   end
 
   it 'has the proper primary terms' do
-    expect(new_form.primary_terms).to include *%i[doi alt_title nested_ordered_abstract subject license]
+    expect(new_form.primary_terms).to include *%i[doi alt_title nested_ordered_abstract subject license contributor_advisor]
   end
 
   it 'has the proper secondary terms' do


### PR DESCRIPTION
Move contributor_advisor field from ETD metadata to Default metadata.
Associated changes to update forms, indexers, models, presenters and
specs.

I haven't been able to test this locally, so this will need thorough QA, which I can help with.