### PR TITLE
change protocol to https for geonames uris

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - && \
 RUN gem install bundler
 
 RUN apt-get update -qq && apt-get upgrade -y && \
-  apt-get install -y build-essential libpq-dev mariadb-client nodejs libreoffice imagemagick unzip ghostscript yarn
+  apt-get install -y build-essential libpq-dev mariadb-client nodejs libreoffice imagemagick unzip ghostscript vim yarn
 
 # install clamav for antivirus
 # fetch clamav local database

--- a/lib/hyrax/controlled_vocabularies/location.rb
+++ b/lib/hyrax/controlled_vocabularies/location.rb
@@ -6,10 +6,10 @@ module Hyrax
     class Location < ActiveTriples::Resource
       configure rdf_label: ::RDF::Vocab::GEONAMES.name
 
-      property :parentFeature, predicate: RDF::URI('http://www.geonames.org/ontology#parentFeature'), class_name: 'Hyrax::ControlledVocabularies::Location'
-      property :parentCountry, predicate: RDF::URI('http://www.geonames.org/ontology#parentCountry'), class_name: 'Hyrax::ControlledVocabularies::Location'
-      property :featureCode, predicate: RDF::URI('http://www.geonames.org/ontology#featureCode')
-      property :featureClass, predicate: RDF::URI('http://www.geonames.org/ontology#featureClass')
+      property :parentFeature, predicate: RDF::URI('https://www.geonames.org/ontology#parentFeature'), class_name: 'Hyrax::ControlledVocabularies::Location'
+      property :parentCountry, predicate: RDF::URI('https://www.geonames.org/ontology#parentCountry'), class_name: 'Hyrax::ControlledVocabularies::Location'
+      property :featureCode, predicate: RDF::URI('https://www.geonames.org/ontology#featureCode')
+      property :featureClass, predicate: RDF::URI('https://www.geonames.org/ontology#featureClass')
 
       # Return a tuple of url & label
       def solrize
@@ -60,7 +60,7 @@ module Hyrax
 
       def top_level_element?
         featureCode = self.featureCode.first
-        top_level_codes = [RDF::URI('http://www.geonames.org/ontology#A.PCLI')]
+        top_level_codes = [RDF::URI('https://www.geonames.org/ontology#A.PCLI')]
         featureCode.respond_to?(:rdf_subject) && top_level_codes.include?(featureCode.rdf_subject)
       end
     end

--- a/lib/qa/authorities/geonames.rb
+++ b/lib/qa/authorities/geonames.rb
@@ -33,7 +33,7 @@ module Qa::Authorities
     end
 
     def find_url(id)
-      "http://www.geonames.org/getJSON?geonameId=#{id}&username=#{username}"
+      "https://www.geonames.org/getJSON?geonameId=#{id}&username=#{username}"
     end
 
     private
@@ -42,7 +42,7 @@ module Qa::Authorities
       def parse_authority_response(response)
         response['geonames'].map do |result|
           # Note: the trailing slash is meaningful.
-          { 'id' => "http://sws.geonames.org/#{result['geonameId']}/",
+          { 'id' => "https://sws.geonames.org/#{result['geonameId']}/",
             'label' => label.call(result, translate_fcl(result['fcl'])) }
         end
       end

--- a/lib/scholars_archive/feature_class_uri_to_label.rb
+++ b/lib/scholars_archive/feature_class_uri_to_label.rb
@@ -4,15 +4,15 @@ module ScholarsArchive
   # Translate feature class
   class FeatureClassUriToLabel
     def uri_to_label(uri)
-      { 'http://www.geonames.org/ontology#A' => 'Administrative Boundary',
-        'http://www.geonames.org/ontology#H' => 'Hydrographic',
-        'http://www.geonames.org/ontology#L' => 'Area',
-        'http://www.geonames.org/ontology#P' => 'Populated Place',
-       'http://www.geonames.org/ontology#R' => 'Road / Railroad',
-       'http://www.geonames.org/ontology#S' => 'Spot',
-       'http://www.geonames.org/ontology#T' => 'Hypsographic',
-       'http://www.geonames.org/ontology#U' => 'Undersea',
-       'http://www.geonames.org/ontology#V' => 'Vegetation'
+      { 'https://www.geonames.org/ontology#A' => 'Administrative Boundary',
+        'https://www.geonames.org/ontology#H' => 'Hydrographic',
+        'https://www.geonames.org/ontology#L' => 'Area',
+        'https://www.geonames.org/ontology#P' => 'Populated Place',
+       'https://www.geonames.org/ontology#R' => 'Road / Railroad',
+       'https://www.geonames.org/ontology#S' => 'Spot',
+       'https://www.geonames.org/ontology#T' => 'Hypsographic',
+       'https://www.geonames.org/ontology#U' => 'Undersea',
+       'https://www.geonames.org/ontology#V' => 'Vegetation'
       }[uri]
     end
   end


### PR DESCRIPTION
fixes #2016 

- It looks like we can fix location by switching to https like done in https://github.com/samvera/questioning_authority/pull/307 (it updates `lib/qa/authorities/geonames.rb`)
- `lib/qa/authorities/geonames.rb` is already overridden in ScholarsArchive, so applying the update on this file `geonames.rb` seems to work as well.
