### PR TITLE
fix 500 error on empty label values

### DIFF
--- a/app/indexers/default_work_indexer.rb
+++ b/app/indexers/default_work_indexer.rb
@@ -20,8 +20,8 @@ class DefaultWorkIndexer < Hyrax::WorkIndexer
       language_labels = ScholarsArchive::LanguageService.new.all_labels(object.language)
       peerreviewed_label = ScholarsArchive::PeerreviewedService.new.all_labels(object.peerreviewed)
       triple_powered_properties_for_solr_doc(object, solr_doc)
-      solr_doc['based_near_linked_ssim'] = object.based_near.each.map { |location| location.solrize.second[:label] }
-      solr_doc['based_near_linked_tesim'] = object.based_near.each.map { |location| location.solrize.second[:label] }
+      solr_doc['based_near_linked_ssim'] = object.based_near.each.map { |location| location.solrize.second[:label] if location.solrize.count > 1 }
+      solr_doc['based_near_linked_tesim'] = object.based_near.each.map { |location| location.solrize.second[:label] if location.solrize.count > 1 }
       solr_doc['rights_statement_label_ssim'] = rights_statement_labels
       solr_doc['rights_statement_label_tesim'] = rights_statement_labels
       solr_doc['license_label_ssim'] = license_labels

--- a/app/indexers/default_work_indexer.rb
+++ b/app/indexers/default_work_indexer.rb
@@ -20,8 +20,7 @@ class DefaultWorkIndexer < Hyrax::WorkIndexer
       language_labels = ScholarsArchive::LanguageService.new.all_labels(object.language)
       peerreviewed_label = ScholarsArchive::PeerreviewedService.new.all_labels(object.peerreviewed)
       triple_powered_properties_for_solr_doc(object, solr_doc)
-      solr_doc['based_near_linked_ssim'] = object.based_near.each.map { |location| location.solrize.second[:label] if location.solrize.count > 1 }
-      solr_doc['based_near_linked_tesim'] = object.based_near.each.map { |location| location.solrize.second[:label] if location.solrize.count > 1 }
+      based_near_for_solr_doc(object, solr_doc)
       solr_doc['rights_statement_label_ssim'] = rights_statement_labels
       solr_doc['rights_statement_label_tesim'] = rights_statement_labels
       solr_doc['license_label_ssim'] = license_labels
@@ -44,6 +43,11 @@ class DefaultWorkIndexer < Hyrax::WorkIndexer
 
   def embargo_date_range_string(solr_doc, start_date, end_date)
     solr_doc['embargo_date_range_ssim'] = "#{start_date} to #{end_date}"
+  end
+
+  def based_near_for_solr_doc(object, solr_doc)
+    solr_doc['based_near_linked_ssim'] = object.based_near.each.map { |location| location.solrize.second[:label] if location.solrize.count > 1 }
+    solr_doc['based_near_linked_tesim'] = object.based_near.each.map { |location| location.solrize.second[:label] if location.solrize.count > 1 }
   end
 
   def title_for_solr_doc(object, solr_doc)


### PR DESCRIPTION
skip label assignment if it's empty to prevent server error.

This occurs when a resource comes back with no label, and the indexer tries to access it via `second` operation, resulting in a 500 error https://github.com/osulp/Scholars-Archive/issues/2016#issuecomment-575434644