### PR TITLE
update protocols to properly match FeatureClassUriToLabel

### DIFF
--- a/lib/hyrax/controlled_vocabularies/location.rb
+++ b/lib/hyrax/controlled_vocabularies/location.rb
@@ -6,10 +6,10 @@ module Hyrax
     class Location < ActiveTriples::Resource
       configure rdf_label: ::RDF::Vocab::GEONAMES.name
 
-      property :parentFeature, predicate: RDF::URI('https://www.geonames.org/ontology#parentFeature'), class_name: 'Hyrax::ControlledVocabularies::Location'
-      property :parentCountry, predicate: RDF::URI('https://www.geonames.org/ontology#parentCountry'), class_name: 'Hyrax::ControlledVocabularies::Location'
-      property :featureCode, predicate: RDF::URI('https://www.geonames.org/ontology#featureCode')
-      property :featureClass, predicate: RDF::URI('https://www.geonames.org/ontology#featureClass')
+      property :parentFeature, predicate: RDF::URI('http://www.geonames.org/ontology#parentFeature'), class_name: 'Hyrax::ControlledVocabularies::Location'
+      property :parentCountry, predicate: RDF::URI('http://www.geonames.org/ontology#parentCountry'), class_name: 'Hyrax::ControlledVocabularies::Location'
+      property :featureCode, predicate: RDF::URI('http://www.geonames.org/ontology#featureCode')
+      property :featureClass, predicate: RDF::URI('http://www.geonames.org/ontology#featureClass')
 
       # Return a tuple of url & label
       def solrize
@@ -60,7 +60,7 @@ module Hyrax
 
       def top_level_element?
         featureCode = self.featureCode.first
-        top_level_codes = [RDF::URI('https://www.geonames.org/ontology#A.PCLI')]
+        top_level_codes = [RDF::URI('http://www.geonames.org/ontology#A.PCLI')]
         featureCode.respond_to?(:rdf_subject) && top_level_codes.include?(featureCode.rdf_subject)
       end
     end

--- a/lib/qa/authorities/geonames.rb
+++ b/lib/qa/authorities/geonames.rb
@@ -33,7 +33,7 @@ module Qa::Authorities
     end
 
     def find_url(id)
-      "https://www.geonames.org/getJSON?geonameId=#{id}&username=#{username}"
+      "http://www.geonames.org/getJSON?geonameId=#{id}&username=#{username}"
     end
 
     private


### PR DESCRIPTION
FeatureClassUriToLabel stopped working as expected when testing https://github.com/osulp/Scholars-Archive/pull/2017 on staging.

This reverts some changes introduced in https://github.com/osulp/Scholars-Archive/pull/2017. It looks like https is only required in `parse_authority_response` (lib/qa/authorities/geonames.rb) and  `FeatureClassUriToLabel` (lib/scholars_archive/feature_class_uri_to_label.rb) to work properly, so the protocol doesn't have to be changed in the model properties for Location.

Staging:
![image](https://user-images.githubusercontent.com/3486120/73036250-c6d4a180-3dff-11ea-89aa-ad2600b2a488.png)

On production:
![image](https://user-images.githubusercontent.com/3486120/73036355-27fc7500-3e00-11ea-9789-7e36d34fbc84.png)
