### PR TITLE
more refined view

### DIFF
--- a/app/assets/stylesheets/osu.scss
+++ b/app/assets/stylesheets/osu.scss
@@ -609,3 +609,7 @@ button.btn-secondary {
 .form-control:not(.multi_value) {
  width: 99% !important; 
 }
+
+.tombstone-text {
+  word-wrap: break-word;
+}

--- a/app/views/hyrax/base/_tombstoned_work.html.erb
+++ b/app/views/hyrax/base/_tombstoned_work.html.erb
@@ -1,14 +1,20 @@
 <% @content_block = ContentBlock.find_or_create_by(name: "tombstone-#{@presenter.solr_document.id}") %>
 <% @content_block.update(value: 'Default') unless @content_block.value.present? %>
 <% @content = displayable_content_block @content_block, class: 'col-sm-offset-2 col-sm-9 col-md-offset-1' %>
-<%= raw @content %>
+<div class='row tombstone-text'>
+  <%= raw @content %>
+  </div>
+</div>
 <br>
-<br>
-<p>MLA Citation: <%= export_as_mla_citation(@presenter) %></p>
-<br>
-<p>APA Citation: <%= export_as_apa_citation(@presenter) %></p>
-<br>
-<p>Chicago Citation: <%= export_as_chicago_citation(@presenter) %></p>
+<div class='row'>
+  <h2> Citations </h2>
+  <br>
+  <p>MLA Citation: <%= export_as_mla_citation(@presenter) %></p>
+  <br>
+  <p>APA Citation: <%= export_as_apa_citation(@presenter) %></p>
+  <br>
+  <p>Chicago Citation: <%= export_as_chicago_citation(@presenter) %></p>
+</div>
 <% if can?(:manage, @presenter.admin_set.first) %>
   <br>
   <h2><p> Tombstone Message Editor </p></h2>


### PR DESCRIPTION
<img width="1447" alt="Screen Shot 2020-03-09 at 12 57 05 PM" src="https://user-images.githubusercontent.com/6424683/76252134-88efd900-6205-11ea-9184-2f874b23b953.png">

Fixes #2055

This should encapsulate the tombstone info much better. Citations now has a label too and word wrapping happens for text that is too long.