### PR TITLE
remove render_partial.action_view

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -4,7 +4,6 @@ Honeycomb.configure do |config|
   config.notification_events = %w[
     sql.active_record
     render_template.action_view
-    render_partial.action_view
     render_collection.action_view
     process_action.action_controller
     send_file.action_controller


### PR DESCRIPTION
don't emit render_partial.action_view spans that don't contain much useful data to cut event traffic. those spans are roughly 28% of our event traffic for SA