### PR TITLE
Revert "Feature/ability expanded"

### DIFF
--- a/app/controllers/concerns/scholars_archive/works_controller_behavior.rb
+++ b/app/controllers/concerns/scholars_archive/works_controller_behavior.rb
@@ -13,16 +13,6 @@ module ScholarsArchive
         curation_concern = ActiveFedora::Base.find(params[:id])
         redirect_to(main_app.polymorphic_path(curation_concern), status: :moved_permanently) and return if curation_concern.class != _curation_concern_type
       end
-
-      # OVERRIDE FROM HYRAX TO INSERT SOLR DOCUMENT INTO DOCUMENT LIST IF THE WORK WAS INGESTED BY THE CURRENT USER
-      def search_result_document(search_params)
-        _, document_list = search_results(search_params)
-        solr_doc = ::SolrDocument.find(params[:id])
-        document_list << solr_doc if solr_doc.depositor == current_user.username
-        return document_list.first unless document_list.empty?
-
-        document_not_found!
-      end
     end
 
     def new


### PR DESCRIPTION
Reverts osulp/Scholars-Archive#2044

This is believed to introduce errors when a non-logged in user tries to view a show page:

I, [2020-07-07T11:18:40.607845 #18189]  INFO -- : [cd939825-06dd-42a6-ab20-9c9ca7d41ab3] method=GET path=/concern/graduate_thesis_or_dissertations/kd17ct94m format=html controller=Hyrax::GraduateThesisOrDissertationsController action=show status=500 error='NoMethodError: undefined method `username' for nil:NilClass' duration=336.49 view=0.00 db=12.22 params={"locale"=>"en"} time=2020-07-07 11:18:40 -0700