### PR TITLE
Revert "updates to allow admin to edit works (#2095)"

### DIFF
--- a/.rubocop_fix_me.yml
+++ b/.rubocop_fix_me.yml
@@ -42,7 +42,6 @@ Metrics/AbcSize:
     - 'lib/scholars_archive/validators/nested_related_items_validator.rb'
     - 'lib/hyrax/controlled_vocabularies/location.rb'
     - 'app/services/scholars_archive/degree_level_service.rb'
-    - 'app/models/ability.rb'
 
 Metrics/MethodLength:
   Exclude:

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -22,11 +22,11 @@ class Ability
     # end
 
     can %i[edit update], SolrDocument do |solr_doc|
-      AdminSet.where(title: solr_doc.admin_set).first.edit_users.include?(current_user.username) || current_user.admin?
+      AdminSet.where(title: solr_doc.admin_set).first.edit_users.include?(current_user.username)
     end
 
     can %i[edit update], ActiveFedora::Base do |record|
-      record.admin_set.edit_users.include?(current_user.username) || current_user.admin?
+      record.admin_set.edit_users.include?(current_user.username)
     end
   end
 end


### PR DESCRIPTION
Reverts osulp/Scholars-Archive#2095

This one needs more testing, so we could revert it for now. It seems to be causing file attachments to not work properly on production.