### PR TITLE
Revert "add edit ability to check if admin set of solr doc includes current user"

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -20,13 +20,5 @@ class Ability
     # if user_groups.include? 'special_group'
     #   can [:create], ActiveFedora::Base
     # end
-
-    can %i[edit update], SolrDocument do |solr_doc|
-      AdminSet.where(title: solr_doc.admin_set).first.edit_users.include?(current_user.username)
-    end
-
-    can %i[edit update], ActiveFedora::Base do |record|
-      record.admin_set.edit_users.include?(current_user.username)
-    end
   end
 end


### PR DESCRIPTION
Reverts osulp/Scholars-Archive#2048

We can revert this one as well to resolve `undefined method `edit_users' for nil:NilClass`. When we are ready to push this update, we should also test for the anonymous user. This one is related to changes in PR https://github.com/osulp/Scholars-Archive/pull/2104 