### PR TITLE
Revert 2105 revert 2048 feature/allow editing if manager

### DIFF
--- a/.rubocop_fix_me.yml
+++ b/.rubocop_fix_me.yml
@@ -42,6 +42,7 @@ Metrics/AbcSize:
     - 'lib/scholars_archive/validators/nested_related_items_validator.rb'
     - 'lib/hyrax/controlled_vocabularies/location.rb'
     - 'app/services/scholars_archive/degree_level_service.rb'
+    - 'app/models/ability.rb'
 
 Metrics/MethodLength:
   Exclude:

--- a/.rubocop_fix_me.yml
+++ b/.rubocop_fix_me.yml
@@ -42,7 +42,6 @@ Metrics/AbcSize:
     - 'lib/scholars_archive/validators/nested_related_items_validator.rb'
     - 'lib/hyrax/controlled_vocabularies/location.rb'
     - 'app/services/scholars_archive/degree_level_service.rb'
-    - 'app/models/ability.rb'
 
 Metrics/MethodLength:
   Exclude:

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -20,5 +20,13 @@ class Ability
     # if user_groups.include? 'special_group'
     #   can [:create], ActiveFedora::Base
     # end
+
+    can %i[edit update], SolrDocument do |solr_doc|
+      AdminSet.where(title: solr_doc.admin_set).first.edit_users.include?(current_user.username)
+    end
+
+    can %i[edit update], ActiveFedora::Base do |record|
+      record.admin_set.edit_users.include?(current_user.username)
+    end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -22,7 +22,7 @@ class Ability
     # end
 
     can %i[edit update], SolrDocument do |solr_doc|
-      AdminSet.where(title: solr_doc.admin_set).first.edit_users.include?(current_user.username) || current_user.admin?
+      (AdminSet.where(title: solr_doc.admin_set).first.edit_users.include?(current_user.username) || current_user.admin?) if solr_doc.admin_set.present? && current_user.present?
     end
 
     can %i[edit update], ActiveFedora::Base do |record|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -22,11 +22,11 @@ class Ability
     # end
 
     can %i[edit update], SolrDocument do |solr_doc|
-      AdminSet.where(title: solr_doc.admin_set).first.edit_users.include?(current_user.username)
+      AdminSet.where(title: solr_doc.admin_set).first.edit_users.include?(current_user.username) || current_user.admin?
     end
 
     can %i[edit update], ActiveFedora::Base do |record|
-      record.admin_set.edit_users.include?(current_user.username)
+      record.admin_set.edit_users.include?(current_user.username) || current_user.admin?
     end
   end
 end


### PR DESCRIPTION
Reverts osulp/Scholars-Archive#2105

Updates:
- Bugfix for error found in production: `undefined method edit_users' for nil:NilClass`
- Merge with https://github.com/osulp/Scholars-Archive/pull/2095
