### PR TITLE
update location links and enable search and facets

### DIFF
--- a/lib/hyrax/controlled_vocabularies/location.rb
+++ b/lib/hyrax/controlled_vocabularies/location.rb
@@ -31,7 +31,7 @@ module Hyrax
 
           @label = @label.first
           parent_hierarchy.each do |p|
-            @label = "#{@label} >> #{p.first.rdf_label.first}"
+            @label = "#{@label.strip}, #{p.first.rdf_label.first}"
           end
         end
         Array(@label)

--- a/spec/workers/fetch_graph_worker_spec.rb
+++ b/spec/workers/fetch_graph_worker_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe FetchGraphWorker, type: :worker do
 
       it 'fetches a work and indexes its linked data labels' do
         worker.perform(work.id, work.depositor)
-        expect(SolrDocument.find(work.id)['based_near_linked_tesim'].first).to eq 'Chabre, Wayne$Chabre, Wayne$https://sws.geonames.org/5761960/'
+        expect(SolrDocument.find(work.id)['based_near_linked_tesim'].first).to eq 'Chabre, Wayne$https://sws.geonames.org/5761960/'
       end
 
       it 'fetches a work and indexes its linked data label for search' do
         worker.perform(work.id, work.depositor)
-        expect(SolrDocument.find(work.id)['based_near_label_tesim'].first).to eq 'Chabre, Wayne$Chabre, Wayne'
+        expect(SolrDocument.find(work.id)['based_near_label_tesim'].first).to eq 'Chabre, Wayne'
       end
     end
 

--- a/spec/workers/fetch_graph_worker_spec.rb
+++ b/spec/workers/fetch_graph_worker_spec.rb
@@ -23,7 +23,12 @@ RSpec.describe FetchGraphWorker, type: :worker do
 
       it 'fetches a work and indexes its linked data labels' do
         worker.perform(work.id, work.depositor)
-        expect(SolrDocument.find(work.id)['based_near_linked_tesim'].first).to eq 'Chabre, Wayne'
+        expect(SolrDocument.find(work.id)['based_near_linked_tesim'].first).to eq 'Chabre, Wayne$Chabre, Wayne$https://sws.geonames.org/5761960/'
+      end
+
+      it 'fetches a work and indexes its linked data label for search' do
+        worker.perform(work.id, work.depositor)
+        expect(SolrDocument.find(work.id)['based_near_label_tesim'].first).to eq 'Chabre, Wayne$Chabre, Wayne'
       end
     end
 


### PR DESCRIPTION
fixes https://github.com/osulp/Scholars-Archive/issues/1694

Location field updates:
- use commas as separator and remove extra spaces in location links
- update fetch graph worker to commit based_near_label to enable search and facets for location

Show page for location:
![image](https://user-images.githubusercontent.com/3486120/88428949-aaafbe00-cdaa-11ea-88dd-4a4809f465c0.png)


Search and facets for location:
![image](https://user-images.githubusercontent.com/3486120/88428934-a2f01980-cdaa-11ea-92a0-3b8cfbd5c3a8.png)
