### PR TITLE
update visibility options in forms

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -130,6 +130,6 @@ module ApplicationHelper
   end
 
   def option_visible_to_depositor?(model, user)
-    user.admin? == false && model.class == GraduateThesisOrDissertation ? false : true
+    user.admin? == false && [GraduateThesisOrDissertation, HonorsCollegeThesis, GraduateProject, UndergraduateThesisOrProject].include?(model.class) ? false : true
   end
 end

--- a/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
@@ -105,8 +105,68 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
 
       it { expect(page).to have_selector(open_option_id) }
       it { expect(page).to have_selector(embargo_option_id) }
+      it { expect(page).not_to have_selector(restricted_option_id) }
+      it { expect(page).not_to have_selector(authenticated_option_id) }
+    end
+  end
+
+  context 'with visibility options on honors_college_thesis' do
+    let(:form) do
+      Hyrax::HonorsCollegeThesisForm.new(work, nil, controller)
+    end
+    let(:work) { HonorsCollegeThesis.new }
+    let(:model_name) { 'honors_college_thesis' }
+
+    context 'when admin users' do
+      before do
+        allow(user).to receive(:admin?).and_return(true)
+      end
+
+      it { expect(page).to have_selector(open_option_id) }
+      it { expect(page).to have_selector(embargo_option_id) }
       it { expect(page).to have_selector(restricted_option_id) }
       it { expect(page).to have_selector(authenticated_option_id) }
+    end
+
+    context 'when non-admin users' do
+      before do
+        allow(user).to receive(:admin?).and_return(false)
+      end
+
+      it { expect(page).to have_selector(open_option_id) }
+      it { expect(page).to have_selector(embargo_option_id) }
+      it { expect(page).not_to have_selector(restricted_option_id) }
+      it { expect(page).not_to have_selector(authenticated_option_id) }
+    end
+  end
+
+  context 'with visibility options on undergraduate_thesis_or_project' do
+    let(:form) do
+      Hyrax::UndergraduateThesisOrProjectForm.new(work, nil, controller)
+    end
+    let(:work) { UndergraduateThesisOrProject.new }
+    let(:model_name) { 'undergraduate_thesis_or_project' }
+
+    context 'when admin users' do
+      before do
+        allow(user).to receive(:admin?).and_return(true)
+      end
+
+      it { expect(page).to have_selector(open_option_id) }
+      it { expect(page).to have_selector(embargo_option_id) }
+      it { expect(page).to have_selector(restricted_option_id) }
+      it { expect(page).to have_selector(authenticated_option_id) }
+    end
+
+    context 'when non-admin users' do
+      before do
+        allow(user).to receive(:admin?).and_return(false)
+      end
+
+      it { expect(page).to have_selector(open_option_id) }
+      it { expect(page).to have_selector(embargo_option_id) }
+      it { expect(page).not_to have_selector(restricted_option_id) }
+      it { expect(page).not_to have_selector(authenticated_option_id) }
     end
   end
 


### PR DESCRIPTION
fixes https://github.com/osulp/Scholars-Archive/issues/2113

Update forms for `HonorsCollegeThesis`, `GraduateProject`, and `UndergraduateThesisOrProject` models to remove both private and authenticated options and only keep public and embargo options.

![image](https://user-images.githubusercontent.com/3486120/88836072-056e5e80-d18b-11ea-8c07-862eda3fc1a7.png)
