### PR TITLE
Override hyrax language show field to use language label service

### DIFF
--- a/app/views/records/show_fields/_language.html.erb
+++ b/app/views/records/show_fields/_language.html.erb
@@ -1,0 +1,4 @@
+<%# Override from Hyrax to use SA language labels service %>
+<% ScholarsArchive::LanguageService.new.all_labels(record.language).each do |lang| %>
+  <span itemprop="inLanguage"><%= lang %></span><br />
+<% end %>


### PR DESCRIPTION
Fixes #1752 
<img width="433" alt="image" src="https://user-images.githubusercontent.com/11052958/101096461-71ffcc80-3574-11eb-9fb4-6fe51a8f0bb5.png">
