### PR TITLE
Pin mini_racer to 0.2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.2'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'mini_racer', '= 0.2.6', platforms: :ruby
+gem 'libv8', '= 7.3.492.27.1'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # See https://github.com/rails/execjs#readme for more supported runtimes
-gem 'mini_racer', platforms: :ruby
+gem 'mini_racer', '= 0.2.6', platforms: :ruby
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -660,8 +660,8 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    mini_racer (0.3.1)
-      libv8 (~> 8.4.255)
+    mini_racer (0.2.6)
+      libv8 (>= 6.9.411)
     minitest (5.14.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -1073,7 +1073,7 @@ DEPENDENCIES
   jquery-ui-rails
   listen (~> 3.0.5)
   lograge
-  mini_racer
+  mini_racer (= 0.2.6)
   mysql2 (~> 0.5.1)
   net-http-persistent
   poltergeist

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -605,7 +605,7 @@ GEM
     libhoney (1.16.1)
       addressable (~> 2.0)
       http (>= 2.0, < 5.0)
-    libv8 (8.4.255.0)
+    libv8 (7.3.492.27.1)
     link_header (0.0.8)
     linkeddata (3.1.1)
       equivalent-xml (~> 0.6)
@@ -1071,6 +1071,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   jquery-ui-rails
+  libv8 (= 7.3.492.27.1)
   listen (~> 3.0.5)
   lograge
   mini_racer (= 0.2.6)


### PR DESCRIPTION
There must be some kind of depedency on higher versions of mini_racer. Something to do with gcc or libV8