### PR TITLE
Regenerate solr document in fetch graph workers to restore non-stored fields

### DIFF
--- a/app/workers/fetch_failed_graph_worker.rb
+++ b/app/workers/fetch_failed_graph_worker.rb
@@ -9,8 +9,9 @@ class FetchFailedGraphWorker
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
   def perform(pid, val, _controlled_prop)
-    # Fetch the work and the solr_doc
-    solr_doc = SolrDocument.find(pid)
+    # Fetch Work and SolrDoc
+    work = ActiveFedora::Base.find(pid)
+    solr_doc = work.to_solr
 
     if val.respond_to?(:fetch)
       val.fetch(headers: { 'Accept' => default_accept_header })

--- a/app/workers/fetch_graph_worker.rb
+++ b/app/workers/fetch_graph_worker.rb
@@ -11,14 +11,9 @@ class FetchGraphWorker
   def perform(pid, _user_key)
     # Fetch Work and SolrDoc
     work = ActiveFedora::Base.find(pid)
-    solr_doc = SolrDocument.find(pid)
+    solr_doc = work.to_solr
     # TODO: ADD BACK IN WHEN SETTING UP EMAIL
     # user = User.where(email: user_key).first
-
-    # Use 0 for version to tell Solr that the document just needs to exist to be updated
-    # Versions dont need to match
-    solr_doc.response['response']['docs'].first['_version_'] = 0
-    solr_doc['_version_'] = 0
 
     # Iterate over Controller Props values
     work.attributes['based_near'].each do |val|


### PR DESCRIPTION
Fixes #2167

The problem came from pulling the solr document back out of solr. Any field that's not stored in solr (stored = false) can not be retrieved, so when we fetched the doc to update it we lost all stored fields including `creator_sim`.

This should also fix some missing metadata issues. Other fields that were likely lost because of this bug:
```
 "title_sim",
 "graduation_year_sim",
 "creator_sim",
 "degree_field_sim",
 "degree_level_sim",
 "degree_name_sim",
 "language_sim",
 "nested_ordered_creator_sim",
 "nested_ordered_title_sim",
 "peerreviewed_sim",
 "publisher_sim",
 "resource_type_sim",
 "generic_type_sim",
 "admin_set_sim",
 "human_readable_type_sim",
 "rights_statement_sim",
 "license_sim"
```