### PR TITLE
Stop using nested ordered contributor field for facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -75,7 +75,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('conference_name', :facetable), limit: 5, label: 'Conference Name'
     config.add_facet_field solr_name('conference_section', :facetable), limit: 5, label: 'Conference Section/Track'
     config.add_facet_field 'creator_sim', label: 'Creator', limit: 5
-    config.add_facet_field 'nested_ordered_contributor_label_ssim', label: 'Contributor', limit: 5, helper_method: :parsed_index
+    config.add_facet_field 'contributor_sim', label: 'Contributor', limit: 5
 
 #    config.add_facet_field 'date_facet_yearly_ssim', :label => 'Date', :range => true
     config.add_facet_field('date_facet_yearly_ssim') do |field|

--- a/app/models/concerns/scholars_archive/has_solr_labels.rb
+++ b/app/models/concerns/scholars_archive/has_solr_labels.rb
@@ -29,6 +29,7 @@ module ScholarsArchive
           ordered_title_labels = nested_ordered_title.map { |i| (i.instance_of? NestedOrderedTitle) ? "#{i.title.first}$#{i.index.first}" : i }.select(&:present?)
           ordered_abstract_labels = nested_ordered_abstract.map { |i| (i.instance_of? NestedOrderedAbstract) ? "#{i.abstract.first}$#{i.index.first}" : i }.select(&:present?)
           ordered_contributor_labels = nested_ordered_contributor.map { |i| (i.instance_of? NestedOrderedContributor) ? "#{i.contributor.first}$#{i.index.first}" : i }.select(&:present?)
+          contributor_labels = nested_ordered_contributor.map { |i| (i.instance_of? NestedOrderedContributor) ? "#{i.contributor.first}" : i }.select(&:present?).uniq
           ordered_additional_information_labels = nested_ordered_additional_information.map { |i| (i.instance_of? NestedOrderedAdditionalInformation) ? "#{i.additional_information.first}$#{i.index.first}" : i }.select(&:present?)
 
           labels = [{label: 'nested_geo_label', data: labels },
@@ -53,6 +54,7 @@ module ScholarsArchive
           doc[ActiveFedora.index_field_mapper.solr_name('rights_statement', :facetable)] = rights_statement.first
           doc[ActiveFedora.index_field_mapper.solr_name('license', :facetable)] = license.first
           doc['creator_sim'] = creator_labels
+          doc['contributor_sim'] = contributor_labels
         end
       end
     end


### PR DESCRIPTION
Use the creator facet model for contributor in order to remove duplicate facet values from display. This was caused by the ordered information being part of the facet value on the backend but only the label being displayed on the frontend.

Fixes #2163 

As noted in #2163 to look for additional fields this could be happening to, this is the only facet remaining with this issue.
Needs #2177 to be fully effective.