### PR TITLE
Replace sorting fields with system created dates and non-ordered titles

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -13,7 +13,7 @@ class CatalogController < ApplicationController
   before_action :enforce_show_permissions, only: :show
 
   def self.uploaded_field
-    solr_name('system_create', :stored_sortable, type: :date)
+    solr_name('date_uploaded', :stored_sortable, type: :date)
   end
 
   def self.title_field
@@ -21,7 +21,7 @@ class CatalogController < ApplicationController
   end
 
   def self.modified_field
-    solr_name('system_modified', :stored_sortable, type: :date)
+    solr_name('date_sort_combined', :stored_sortable, type: :date)
   end
 
   configure_blacklight do |config|

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -13,7 +13,7 @@ class CatalogController < ApplicationController
   before_action :enforce_show_permissions, only: :show
 
   def self.uploaded_field
-    solr_name('date_uploaded', :stored_sortable, type: :date)
+    solr_name('system_create', :stored_sortable, type: :date)
   end
 
   def self.title_field
@@ -21,7 +21,7 @@ class CatalogController < ApplicationController
   end
 
   def self.modified_field
-    solr_name('date_created', :stored_sortable, type: :date)
+    solr_name('system_modified', :stored_sortable, type: :date)
   end
 
   configure_blacklight do |config|

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -597,10 +597,10 @@ class CatalogController < ApplicationController
     config.add_sort_field "score desc, #{uploaded_field} desc", label: 'relevance'
     config.add_sort_field "#{title_field} asc", label: 'Title [A-Z]'
     config.add_sort_field "#{title_field} desc", label: 'Title [Z-A]'
+    config.add_sort_field "#{modified_field} desc", label: "date created \u25BC"
+    config.add_sort_field "#{modified_field} asc", label: "date created \u25B2"
     config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
     config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
-    config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
-    config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -17,7 +17,7 @@ class CatalogController < ApplicationController
   end
 
   def self.title_field
-    solr_name('nested_ordered_title_label', :stored_sortable)
+    solr_name('title', :stored_sortable)
   end
 
   def self.modified_field

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# indexes collection metadata
+class CollectionIndexer < Hyrax::CollectionWithBasicMetadataIndexer
+
+  include ScholarsArchive::IndexesCombinedSortDate
+
+  # Uncomment this block if you want to add custom indexing behavior:
+  def generate_solr_document
+    super.tap do |solr_doc|
+      index_combined_date_field(object, solr_doc)
+    end
+  end
+end

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -2,7 +2,6 @@
 
 # indexes collection metadata
 class CollectionIndexer < Hyrax::CollectionWithBasicMetadataIndexer
-
   include ScholarsArchive::IndexesCombinedSortDate
 
   # Uncomment this block if you want to add custom indexing behavior:

--- a/app/indexers/concerns/scholars_archive/indexes_combined_sort_date.rb
+++ b/app/indexers/concerns/scholars_archive/indexes_combined_sort_date.rb
@@ -5,20 +5,16 @@ module ScholarsArchive
   module IndexesCombinedSortDate
     def index_combined_date_field(object, solr_doc)
       # Figure out which date to use
-      date = nil
-      if object&.date_issued.present? then
-        date = object.date_issued
-      elsif object&.date_created.present? then
-        date = object.date_created
-      elsif object&.date_copyright.present? then
-        date = object.date_copyright
-      end
+      date = if object&.date_issued.present?
+               Date.edtf(object.date_issued)
+             elsif object&.date_created.present?
+               Date.edtf(object.date_created)
+             elsif object&.date_copyright.present?
+               Date.edtf(object.date_copyright)
+             end
 
-      # Convert date to EDTF format and grap the first value if it's a range
-      date = Date.edtf(date)
-      if date.instance_of? EDTF::Interval
-        date = date.first
-      end
+      # Grab the first value if it's a range
+      date = date.first if date.instance_of? EDTF::Interval
 
       # Add date to index
       solr_doc['date_sort_combined_dtsi'] = date

--- a/app/indexers/concerns/scholars_archive/indexes_combined_sort_date.rb
+++ b/app/indexers/concerns/scholars_archive/indexes_combined_sort_date.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ScholarsArchive
+  # This module can be mixed in on an indexer in order to combine date fields into one indexed field
+  module IndexesCombinedSortDate
+    def index_combined_date_field(object, solr_doc)
+      # Figure out which date to use
+      date = nil
+      if object&.date_issued.present? then
+        date = object.date_issued
+      elsif object&.date_created.present? then
+        date = object.date_created
+      elsif object&.date_copyright.present? then
+        date = object.date_copyright
+      end
+
+      # Convert date to EDTF format and grap the first value if it's a range
+      date = Date.edtf(date)
+      if date.instance_of? EDTF::Interval
+        date = date.first
+      end
+
+      # Add date to index
+      solr_doc['date_sort_combined_dtsi'] = date
+    end
+  end
+end

--- a/app/indexers/default_work_indexer.rb
+++ b/app/indexers/default_work_indexer.rb
@@ -11,6 +11,7 @@ class DefaultWorkIndexer < Hyrax::WorkIndexer
   # Fetch remote labels for based_near. You can remove this if you don't want
   # this behavior
   include ScholarsArchive::IndexesLinkedMetadata
+  include ScholarsArchive::IndexesCombinedSortDate
 
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
@@ -30,6 +31,7 @@ class DefaultWorkIndexer < Hyrax::WorkIndexer
       solr_doc['peerreviewed_label_tesim'] = peerreviewed_label
       solr_doc['replaces_ssim'] = object.replaces
       title_for_solr_doc(object, solr_doc)
+      index_combined_date_field(object, solr_doc)
 
       # Check if embargo is active
       if object&.embargo && object.embargo.active?

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,5 +5,5 @@ class Collection < ActiveFedora::Base
   include ::Hyrax::CollectionBehavior
   # You can replace these metadata if they're not suitable
   include Hyrax::BasicMetadata
-  self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
+  self.indexer = CollectionIndexer
 end

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -77,9 +77,9 @@
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
       -->
-    <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
+    <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0" sortMissingLast="true"/>
     <!-- A Trie based date field for faster date range queries and date faceting. -->
-    <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
+    <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0" sortMissingLast="true"/>
     
     
     <!-- This point type indexes the coordinates as separate fields (subFields)

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -77,9 +77,9 @@
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
       -->
-    <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
+    <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0" sortMissingLast="true"/>
     <!-- A Trie based date field for faster date range queries and date faceting. -->
-    <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
+    <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0" sortMissingLast="true"/>
     
     
     <!-- This point type indexes the coordinates as separate fields (subFields)


### PR DESCRIPTION
`title_ssi` is populated with the first ordered or unordered title, so that one should be reasonably similar behavior.
The system fields are generated by the actor stack and guaranteed to be on works, unlike `date_created` which is an optional field. `date_uploaded` is only applied to works, so collections get miss-sorted.

Reverts and Fixes #667