### PR TITLE
Fix misunderstanding of safe navigation operation and refactor grabbing sorting date

### DIFF
--- a/app/indexers/concerns/scholars_archive/indexes_combined_sort_date.rb
+++ b/app/indexers/concerns/scholars_archive/indexes_combined_sort_date.rb
@@ -4,20 +4,29 @@ module ScholarsArchive
   # This module can be mixed in on an indexer in order to combine date fields into one indexed field
   module IndexesCombinedSortDate
     def index_combined_date_field(object, solr_doc)
-      # Figure out which date to use
-      date = if object&.date_issued.present?
-               Date.edtf(object.date_issued)
-             elsif object&.date_created.present?
-               Date.edtf(object.date_created)
-             elsif object&.date_copyright.present?
-               Date.edtf(object.date_copyright)
-             end
-
+      date = edtf_sorting_date(object)
       # Grab the first value if it's a range
       date = date.first if date.instance_of? EDTF::Interval
 
       # Add date to index
       solr_doc['date_sort_combined_dtsi'] = date
+    end
+
+    private
+
+    # Get the date for the date created sorting as an EDTF object
+    def edtf_sorting_date(object)
+      # Figure out which date to use
+      date = if object.respond_to?(:date_issued) && object.date_issued.present?
+               object.date_issued
+             elsif object.respond_to?(:date_created) && object.date_created.present?
+               object.date_created
+             elsif object.respond_to?(:date_copyright) && object.date_copyright.present?
+               object.date_copyright
+             end
+      # Sometimes the date is multivalue. Convert to array, pick the first, and parse for EDTF
+      # If it doesn't parse, we get nil and just don't index for sorting
+      date = Date.edtf(Array(date).first)
     end
   end
 end


### PR DESCRIPTION
Ruby's safe navigation operator is great for pre-catching NoMethodError exception while traversing objects, but it only prevents calling a method on Nil. I previously understood it to also prevent exceptions when calling a method that doesn't exist