### PR TITLE
Flatten alpha channel in image derivatives to remove black backgrounds

### DIFF
--- a/config/initializers/hacks/hydra_derivatives_processors_image_hack.rb
+++ b/config/initializers/hacks/hydra_derivatives_processors_image_hack.rb
@@ -8,8 +8,9 @@ Hydra::Derivatives::Processors::Image.class_eval do
         # Combine all ImageMagick options together and add the `-type TrueColor` option to preserve colorspace information
         # This is a fix as described in https://github.com/osulp/Scholars-Archive/issues/2143
         xfrm.combine_options do |x|
-          x.type('TrueColor')
           x.flatten
+          x.alpha('flatten')
+          x.type('TrueColor')
           x.resize(size)
         end
       end


### PR DESCRIPTION
After and before:
![image](https://user-images.githubusercontent.com/11052958/108920208-209e3100-75e9-11eb-8537-fb5586050640.png)

Fixes #2180