### PR TITLE
Prep for improved title sorting by indexing into title_ssort

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -611,6 +611,10 @@ class CatalogController < ApplicationController
     config.add_sort_field "score desc, #{uploaded_field} desc", label: 'Relevance'
     config.add_sort_field "#{title_field} asc", label: 'Title [A-Z]'
     config.add_sort_field "#{title_field} desc", label: 'Title [Z-A]'
+    # Replace these with above title_field entries once title_ssort is indexed.
+    # See https://github.com/osulp/Scholars-Archive/issues/1809
+    # config.add_sort_field "title_ssort asc", label: 'Title [A-Z]'
+    # config.add_sort_field "title_ssort desc", label: 'Title [Z-A]'
     config.add_sort_field "#{modified_field} desc", label: "Date Created \u25BC"
     config.add_sort_field "#{modified_field} asc", label: "Date Created \u25B2"
     config.add_sort_field "#{uploaded_field} desc", label: "Date Uploaded \u25BC"

--- a/app/indexers/default_work_indexer.rb
+++ b/app/indexers/default_work_indexer.rb
@@ -53,6 +53,7 @@ class DefaultWorkIndexer < Hyrax::WorkIndexer
     else
       solr_doc['title_ssi'] = object.title.first
     end
+    solr_doc['title_ssort'] = solr_doc['title_ssi']
   end
 
   def triple_powered_properties_for_solr_doc(object, solr_doc)


### PR DESCRIPTION
Once index is done, the catalog controller can be updated to use title_ssort

This is half of #1809
The second half can be finished once the reindex is finished