### PR TITLE
Add date_uploaded default value on bulk ingest

### DIFF
--- a/lib/tasks/bulk_ingest_csv.rake
+++ b/lib/tasks/bulk_ingest_csv.rake
@@ -38,6 +38,7 @@ def ingest_work(logger, row, file_path, user)
 
   # Set properties
   work = set_work_properties(logger, work, row)
+  work.date_uploaded = Hyrax::TimeService.time_in_utc
   work.depositor = u.username
   work&.save
 


### PR DESCRIPTION
fixes #2202 
I went with just setting `date_uploaded` on the work because I was unsure of the implications of using the actor stack and how that would interact with either creating our own Sipity entity or updating the one that would be created by an actor.