### PR TITLE
Update blacklight_oai_provider to newest upstream release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'redis', '~> 3.0'
 gem 'sidekiq', '5.0.2'
 gem 'ffi', '~> 1.9.24'
 
-gem 'blacklight_oai_provider', git: 'https://github.com/UNC-Libraries/blacklight_oai_provider.git', branch: 'master'
+gem 'blacklight_oai_provider'
 gem 'blacklight_range_limit'
 gem 'edtf', github: 'inukshuk/edtf-ruby', branch: 'master'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/UNC-Libraries/blacklight_oai_provider.git
-  revision: 4cb048bd52fe0d3ab4ae5f80fd57d7fd13f901d5
-  branch: master
-  specs:
-    blacklight_oai_provider (1.4.1)
-      blacklight (>= 6.1)
-      oai (~> 0.4.0)
-      rails (>= 4.2)
-
-GIT
   remote: https://github.com/inukshuk/edtf-ruby.git
   revision: 7ee86d81ddb7d6503d5b282a409eb43e51f27186
   branch: master
@@ -112,25 +102,25 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (5.2.5)
-      actionpack (= 5.2.5)
+    actioncable (5.2.6)
+      actionpack (= 5.2.6)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailer (5.2.5)
-      actionpack (= 5.2.5)
-      actionview (= 5.2.5)
-      activejob (= 5.2.5)
+    actionmailer (5.2.6)
+      actionpack (= 5.2.6)
+      actionview (= 5.2.6)
+      activejob (= 5.2.6)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (5.2.5)
-      actionview (= 5.2.5)
-      activesupport (= 5.2.5)
+    actionpack (5.2.6)
+      actionview (= 5.2.6)
+      activesupport (= 5.2.6)
       rack (~> 2.0, >= 2.0.8)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.2.5)
-      activesupport (= 5.2.5)
+    actionview (5.2.6)
+      activesupport (= 5.2.6)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
@@ -154,26 +144,26 @@ GEM
     active_encode (0.7.0)
       rails
       sprockets (< 4)
-    activejob (5.2.5)
-      activesupport (= 5.2.5)
+    activejob (5.2.6)
+      activesupport (= 5.2.6)
       globalid (>= 0.3.6)
-    activemodel (5.2.5)
-      activesupport (= 5.2.5)
+    activemodel (5.2.6)
+      activesupport (= 5.2.6)
     activemodel-serializers-xml (1.0.2)
       activemodel (> 5.x)
       activesupport (> 5.x)
       builder (~> 3.1)
-    activerecord (5.2.5)
-      activemodel (= 5.2.5)
-      activesupport (= 5.2.5)
+    activerecord (5.2.6)
+      activemodel (= 5.2.6)
+      activesupport (= 5.2.6)
       arel (>= 9.0)
     activerecord-import (1.0.8)
       activerecord (>= 3.2)
-    activestorage (5.2.5)
-      actionpack (= 5.2.5)
-      activerecord (= 5.2.5)
+    activestorage (5.2.6)
+      actionpack (= 5.2.6)
+      activerecord (= 5.2.6)
       marcel (~> 1.0.0)
-    activesupport (5.2.5)
+    activesupport (5.2.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -186,8 +176,8 @@ GEM
       rails (>= 4.2)
     arel (9.0.0)
     ast (2.4.1)
-    autoprefixer-rails (10.2.4.0)
-      execjs
+    autoprefixer-rails (10.2.5.0)
+      execjs (< 2.8.0)
     awesome_nested_set (3.4.0)
       activerecord (>= 4.0.0, < 7.0)
     aws-eventstream (1.1.1)
@@ -239,6 +229,9 @@ GEM
     blacklight_advanced_search (6.4.1)
       blacklight (~> 6.0, >= 6.0.1)
       parslet
+    blacklight_oai_provider (6.1.1)
+      blacklight (~> 6.0)
+      oai (~> 1.0)
     blacklight_range_limit (7.0.0)
       blacklight
       jquery-rails
@@ -542,7 +535,7 @@ GEM
       hydra-derivatives (~> 3.0)
       hydra-file_characterization (~> 1.0)
       hydra-pcdm (>= 0.9)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     iiif_manifest (0.5.0)
@@ -652,7 +645,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.9.0)
+    loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -660,14 +653,14 @@ GEM
     mailboxer (0.15.1)
       carrierwave (>= 0.5.8)
       rails (>= 5.0.0)
-    marcel (1.0.0)
+    marcel (1.0.1)
     memoist (0.16.2)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
     mini_magick (4.11.0)
-    mini_mime (1.0.2)
+    mini_mime (1.1.0)
     mini_portile2 (2.4.0)
     mini_racer (0.2.6)
       libv8 (>= 6.9.411)
@@ -693,7 +686,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.4)
       nokogiri (~> 1.8, >= 1.8.4)
-    oai (0.4.0)
+    oai (1.1.0)
       builder (>= 3.1.0)
       faraday
       faraday_middleware
@@ -743,18 +736,18 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rails (5.2.5)
-      actioncable (= 5.2.5)
-      actionmailer (= 5.2.5)
-      actionpack (= 5.2.5)
-      actionview (= 5.2.5)
-      activejob (= 5.2.5)
-      activemodel (= 5.2.5)
-      activerecord (= 5.2.5)
-      activestorage (= 5.2.5)
-      activesupport (= 5.2.5)
+    rails (5.2.6)
+      actioncable (= 5.2.6)
+      actionmailer (= 5.2.6)
+      actionpack (= 5.2.6)
+      actionview (= 5.2.6)
+      activejob (= 5.2.6)
+      activemodel (= 5.2.6)
+      activerecord (= 5.2.6)
+      activestorage (= 5.2.6)
+      activesupport (= 5.2.6)
       bundler (>= 1.3.0)
-      railties (= 5.2.5)
+      railties (= 5.2.6)
       sprockets-rails (>= 2.0.0)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
@@ -767,9 +760,9 @@ GEM
       loofah (~> 2.3)
     rails_autolink (1.1.6)
       rails (> 3.1)
-    railties (5.2.5)
-      actionpack (= 5.2.5)
-      activesupport (= 5.2.5)
+    railties (5.2.6)
+      actionpack (= 5.2.6)
+      activesupport (= 5.2.6)
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
@@ -1050,7 +1043,7 @@ PLATFORMS
 DEPENDENCIES
   bagit (~> 0.4.1)
   blacklight_advanced_search
-  blacklight_oai_provider!
+  blacklight_oai_provider
   blacklight_range_limit
   browse-everything
   byebug

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -7,7 +7,7 @@ class CatalogController < ApplicationController
   include Hydra::Catalog
   include Hydra::Controller::ControllerBehavior
 
-  include BlacklightOaiProvider::CatalogControllerBehavior
+  include BlacklightOaiProvider::Controller
 
   # This filter applies the hydra access controls
   before_action :enforce_show_permissions, only: :show

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -3,7 +3,7 @@
 # solr document object
 class SolrDocument
   include Blacklight::Solr::Document
-  include BlacklightOaiProvider::SolrDocumentBehavior
+  include BlacklightOaiProvider::SolrDocument
   include Blacklight::Gallery::OpenseadragonSolrDocument
 
   # Adds Hyrax behaviors to the SolrDocument.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   resources :other_options, only: [:destroy]
 
-  concern :oai_provider, BlacklightOaiProvider::Routes::Provider.new
+  concern :oai_provider, BlacklightOaiProvider::Routes.new
 
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
   get '/downloads/:id(.:format)', to: 'scholars_archive/downloads#show', as: 'download'


### PR DESCRIPTION
This update removes our forked version of blacklight_oai_provider and replaces it with the official projectblacklight version. Are previous fork was forked by UNC and they have archived that repo in favor of projectblacklight.

Fixes #2231 