### PR TITLE
Configure OAI sets for new blacklight_oai_provider gem

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -635,8 +635,11 @@ class CatalogController < ApplicationController
         limit: 50,
         timestamp_field: 'system_create_dtsi',
         timestamp_method: 'system_created',
-        set_fields: 'isPartOf_ssim',
-        set_class: '::OaiSet'
+        set_fields: [
+          { 'label': 'title_tesim',
+            'solr_field': 'isPartOf_ssim' }
+        ],
+        set_model: ::OaiSet
       }
     }
   end

--- a/app/models/oai_set.rb
+++ b/app/models/oai_set.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # builds set for oai
-class OaiSet < BlacklightOaiProvider::Set
+class OaiSet < BlacklightOaiProvider::SolrSet
   class << self
     # The Solr repository object (optional)
     attr_accessor :repository
@@ -11,15 +11,6 @@ class OaiSet < BlacklightOaiProvider::Set
 
     # The Solr fields to map to OAI sets. Must be indexed (optional)
     attr_accessor :fields
-
-    # Return an array of all sets, or nil if sets are not supported
-    def all
-      return if @fields.nil?
-
-      params = { rows: 0, facet: true, 'facet.field' => @fields }
-      response = @repository.search @search_builder.merge(params)
-      sets_from_facets(response.facet_fields) if response.facet_fields
-    end
 
     # Return a Solr filter query given a set spec
     def from_spec(spec)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -197,11 +197,11 @@ class SolrDocument
 
   field_semantics.merge!(
     contributor:  %w[contributor_tesim editor_tesim contributor_advisor_tesim contributor_committeemember_tesim oai_academic_affiliation_label oai_other_affiliation_label],
-    coverage:     %w['based_near_label_tesim conferenceLocation_tesim],
+    coverage:     %w[based_near_label_tesim conferenceLocation_tesim],
     creator:      'creator_tesim',
     date:         'date_created_tesim',
-    description:  %w['description_tesim abstract_tesim],
-    format:       %w['file_extent_tesim file_format_tesim],
+    description:  %w[description_tesim abstract_tesim],
+    format:       %w[file_extent_tesim file_format_tesim],
     identifier:   'oai_identifier',
     language:     'language_label_tesim',
     publisher:    'publisher_tesim',
@@ -221,7 +221,7 @@ class SolrDocument
   end
 
   def sets
-    fetch('isPartOf', []).map { |m| BlacklightOaiProvider::Set.new("isPartOf_ssim:#{m}") }
+    fetch('isPartOf', []).map { |m| ::OaiSet.new("isPartOf_ssim:#{m}") }
   end
 
   def oai_nested_related_items_label


### PR DESCRIPTION
Adds the missing set configuration from #2236 