### PR TITLE
Add reindex by Fedora model rake task

### DIFF
--- a/.rubocop_fix_me.yml
+++ b/.rubocop_fix_me.yml
@@ -22,6 +22,7 @@ Metrics/AbcSize:
     - 'app/authorities/scholars_archive/cache_based_authority.rb'
     - 'app/jobs/migrate_creators_no_handles_job.rb'
     - 'app/jobs/reindex_everything_job.rb'
+    - 'app/jobs/reindex_model_job.rb'
     - 'app/controllers/scholars_archive/handles_controller.rb'
     - 'app/controllers/application_controller.rb'
     - 'app/controllers/hyrax/contact_form_controller.rb'
@@ -56,6 +57,7 @@ Metrics/MethodLength:
     - 'app/actors/scholars_archive/actors/nested_fields_operations_actor.rb'
     - 'app/jobs/migrate_creators_no_handles_job.rb'
     - 'app/jobs/reindex_everything_job.rb'
+    - 'app/jobs/reindex_model_job.rb'
     - 'app/controllers/scholars_archive/handles_controller.rb'
     - 'app/controllers/application_controller.rb'
     - 'app/controllers/hyrax/contact_form_controller.rb'
@@ -647,6 +649,7 @@ Style/RescueStandardError:
   Exclude:
     - 'app/jobs/migrate_creators_no_handles_job.rb'
     - 'app/jobs/reindex_everything_job.rb'
+    - 'app/jobs/reindex_model_job.rb'
     - 'app/controllers/application_controller.rb'
     - 'lib/scholars_archive/triple_powered_properties/has_url_validator.rb'
     - 'lib/scholars_archive/embargoes/embargo_releaser.rb'

--- a/app/jobs/reindex_model_job.rb
+++ b/app/jobs/reindex_model_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# reindexes all works of a single model
+class ReindexModelJob < ScholarsArchive::ApplicationJob
+  queue_as :default
+
+  def perform(model)
+    # Make sure logging directory exists and get our logger
+    file_name = "#{Rails.root}/log/sa-reindex/jid-#{job_id}-#{model}.log"
+    dir_name = File.dirname(file_name)
+    FileUtils.mkdir_p(dir_name) unless File.directory?(dir_name)
+    logger = ActiveSupport::Logger.new(file_name)
+
+    index = ActiveFedora::SolrService.get("has_model_ssim:#{model}", rows: 100000)['response']['docs']
+    counter = 0
+
+    logger.info "Reindexing #{model}: #{index.count}"
+    index.each do |work|
+      logger.info "\t reindexing #{work["id"]}"
+      begin
+        ActiveFedora::Base.find(work['id']).update_index
+        counter += 1
+      rescue => e
+        logger.info "Failed to reindex #{work["id"]}: #{e.message}"
+      end
+    end
+    logger.info "Total indexed: #{counter}"
+    logger.info 'Done'
+  end
+end

--- a/app/jobs/reindex_model_job.rb
+++ b/app/jobs/reindex_model_job.rb
@@ -4,24 +4,24 @@
 class ReindexModelJob < ScholarsArchive::ApplicationJob
   queue_as :default
 
-  def perform(model)
+  def perform(model_name, uris)
     # Make sure logging directory exists and get our logger
-    file_name = "#{Rails.root}/log/sa-reindex/jid-#{job_id}-#{model}.log"
+    file_name = "#{Rails.root}/log/sa-reindex/jid-#{job_id}-#{model_name}.log"
     dir_name = File.dirname(file_name)
     FileUtils.mkdir_p(dir_name) unless File.directory?(dir_name)
     logger = ActiveSupport::Logger.new(file_name)
 
-    index = ActiveFedora::SolrService.get("has_model_ssim:#{model}", rows: 100000)['response']['docs']
     counter = 0
 
-    logger.info "Reindexing #{model}: #{index.count}"
-    index.each do |work|
-      logger.info "\t reindexing #{work["id"]}"
+    logger.info "Reindexing #{model_name}: #{uris.count}"
+    uris.each do |uri|
+      work = ActiveFedora::Base.find(ActiveFedora::Base.uri_to_id(uri))
+      logger.info "\t reindexing #{work.id}"
       begin
-        ActiveFedora::Base.find(work['id']).update_index
+        work.update_index
         counter += 1
       rescue => e
-        logger.info "Failed to reindex #{work["id"]}: #{e.message}"
+        logger.info "Failed to reindex #{work.id}: #{e.message}"
       end
     end
     logger.info "Total indexed: #{counter}"

--- a/lib/tasks/reindex_by_model.rake
+++ b/lib/tasks/reindex_by_model.rake
@@ -1,10 +1,12 @@
 namespace :scholars_archive do
   desc "Enqueue a job to resolrize the repository objects"
   task reindex_by_model: :environment do
-    admin_set_map = YAML.load(File.read('config/admin_set_map.yml'))
+    # Fetch all Fedora URIs keyed on their model name
+    fetcher = ActiveFedora::Base::DescendantFetcher.new(ActiveFedora.fedora.base_uri, exclude_self: true)
+    descendants = fetcher.descendant_and_self_uris_partitioned_by_model
 
-    admin_set_map.each do |model, _desc|
-      ReindexModelJob.perform_later(model)
+    descendants.each do |model, uris|
+      ReindexModelJob.perform_later(model, uris)
     end
   end
 end

--- a/lib/tasks/reindex_by_model.rake
+++ b/lib/tasks/reindex_by_model.rake
@@ -1,0 +1,10 @@
+namespace :scholars_archive do
+  desc "Enqueue a job to resolrize the repository objects"
+  task reindex_by_model: :environment do
+    admin_set_map = YAML.load(File.read('config/admin_set_map.yml'))
+
+    admin_set_map.each do |model, _desc|
+      ReindexModelJob.perform_later(model)
+    end
+  end
+end


### PR DESCRIPTION
This is a cool new rake task that grabs all the URIs from Fedora keyed by their model and splits them across multiple sidekiq jobs.
This is a two-point improvement:
- First, now we grab all the Fedora objects, not just works that are already in solr. This means Collections are reindex, those weird AccessControl objects are reindexed, and anything that somehow slipped by the solr index will be indexed.
- Second, more jobs means more threads can be utilized, means a faster reindex.