### PR TITLE
Hacks to grab all fileset ids in grant/revoke_edit_from_members jobs

### DIFF
--- a/config/initializers/grant_edit_from_members_job_hack.rb
+++ b/config/initializers/grant_edit_from_members_job_hack.rb
@@ -1,0 +1,10 @@
+# OVERRIDE: This overrides file_set_ids on GrantEditFromMembersJob and sets
+# the :rows option on the FileSet id query
+#
+# Base file: https://github.com/samvera/hyrax/blob/v2.9.5/app/jobs/hyrax/grant_edit_from_members_job.rb
+Hyrax::GrantEditToMembersJob.class_eval do
+  private
+  def file_set_ids(work)
+    ::FileSet.search_with_conditions({id: work.member_ids}, rows: 10000).map(&:id)
+  end
+end

--- a/config/initializers/revoke_edit_from_members_job_hack.rb
+++ b/config/initializers/revoke_edit_from_members_job_hack.rb
@@ -1,0 +1,10 @@
+# OVERRIDE: This overrides file_set_ids on RevokeEditFromMembersJob and sets
+# the :rows option on the FileSet id query
+#
+# Base file: https://github.com/samvera/hyrax/blob/v2.9.5/app/jobs/hyrax/revoke_edit_from_members_job.rb
+Hyrax::RevokeEditFromMembersJob.class_eval do
+  private
+  def file_set_ids(work)
+    ::FileSet.search_with_conditions({id: work.member_ids}, rows: 10000).map(&:id)
+  end
+end


### PR DESCRIPTION
Fixes #1955 
The problem was when Hyrax goes to query FileSet ids to revoke/grant access to, they didn't specify the number of rows to look for, so they ended up with the default 10.