### PR TITLE
Update conference section predicate

### DIFF
--- a/app/jobs/replace_predicate_job.rb
+++ b/app/jobs/replace_predicate_job.rb
@@ -13,33 +13,25 @@ class ReplacePredicateJob < ScholarsArchive::ApplicationJob
     logger.info "Updating #{ids_and_value.count} works"
     logger.info ids_and_value
     ids_and_value.each do |id, value|
-      logger.info value
-      logger.info id
       work = ActiveFedora::Base.find(id)
-      logger.info "Work Found"
       old_predicate_statement = [work.resource.rdf_subject, ::RDF::URI.new(old_predicate), nil]
-      logger.info "Predicate set"
 
-      if !work.resource.graph.query(old_predicate_statement).statements.empty?
-        logger.info "Loading ORM"
+      unless work.resource.graph.query(old_predicate_statement).statements.empty?
         orm = Ldp::Orm.new(work.ldp_source)
 
-        logger.info ""
-        logger.info "Work found #{work.id}. Updating #{metadata_field}"
-
-        logger.info "Setting to new value: #{value}"
+        logger.info "Work found #{work.id}. Updating #{metadata_field}. Setting to new value: #{value}"
         work.send("#{metadata_field}=", value)
 
-        logger.info "Saving work"
+        logger.info 'Saving work'
         if work.save
           logger.info "Work saved. Removing old #{metadata_field}. Pulling graph from fedora"
 
           logger.info "Deleting #{metadata_field} from graph"
           orm.graph.delete(old_predicate_statement)
 
-          logger.info "Saving the graph"
+          logger.info 'Saving the graph'
           if orm.save
-            logger.info "Graph saved successfully"
+            logger.info 'Graph saved successfully'
             counter += 1
           else
             logger.error "Something went wrong with removing old value from graph #{work.id}"

--- a/app/jobs/replace_predicate_job.rb
+++ b/app/jobs/replace_predicate_job.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# reindexes chunks of uris
+class ReplacePredicateJob < ScholarsArchive::ApplicationJob
+  queue_as :default
+
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
+  def perform(ids_and_value, old_predicate, metadata_field)
+    counter = 0
+    logger = Rails.logger
+
+    logger.info "Updating #{ids_and_value.count} works"
+    logger.info ids_and_value
+    ids_and_value.each do |id, value|
+      logger.info value
+      logger.info id
+      work = ActiveFedora::Base.find(id)
+      logger.info "Work Found"
+      old_predicate_statement = [work.resource.rdf_subject, ::RDF::URI.new(old_predicate), nil]
+      logger.info "Predicate set"
+
+      if !work.resource.graph.query(old_predicate_statement).statements.empty?
+        logger.info "Loading ORM"
+        orm = Ldp::Orm.new(work.ldp_source)
+
+        logger.info ""
+        logger.info "Work found #{work.id}. Updating #{metadata_field}"
+
+        logger.info "Setting to new value: #{value}"
+        work.send("#{metadata_field}=", value)
+
+        logger.info "Saving work"
+        if work.save
+          logger.info "Work saved. Removing old #{metadata_field}. Pulling graph from fedora"
+
+          logger.info "Deleting #{metadata_field} from graph"
+          orm.graph.delete(old_predicate_statement)
+
+          logger.info "Saving the graph"
+          if orm.save
+            logger.info "Graph saved successfully"
+            counter += 1
+          else
+            logger.error "Something went wrong with removing old value from graph #{work.id}"
+          end
+        else
+          logger.error "Something went wrong adding new value #{work.id}"
+        end
+      end
+    # rubocop:disable Style/RescueStandardError
+    rescue => e
+      logger.info "Failed to update #{work.id}: #{e.message}"
+      next
+    end
+    # rubocop:enable Style/RescueStandardError
+    logger.info "Total works updated: #{counter}/#{ids_and_value.count}"
+  end
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
+end

--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -59,7 +59,7 @@ module ScholarsArchive
       end
 
       # multiple: false, until "conference" is converted to a nested attribute so that the location, name, and section are all related/stored together
-      property :conference_section, predicate: ::RDF::URI.new('https://w2id.org/scholarlydata/ontology/conference-ontology.owl#Track'), multiple: false do |index|
+      property :conference_section, predicate: ::RDF::URI.new('https://w3id.org/scholarlydata/ontology/conference-ontology.owl#Track'), multiple: false do |index|
         index.as :stored_searchable, :facetable
       end
 

--- a/lib/tasks/reindex_by_chunk.rake
+++ b/lib/tasks/reindex_by_chunk.rake
@@ -1,13 +1,13 @@
 namespace :scholars_archive do
   desc "Enqueue a job to resolrize repository objects in chunks"
   task :reindex_by_chunk, [:chunk_size] => :environment do |t, args|
-    # Set a minimum chunk size of 100
-    chunk_size = [args[:chunk_size].to_i, 100].max
+    # Set a default value of 100 for chunk_size
+    args.with_defaults(:chunk_size => 100)
     # Fetch all Fedora URIs
     fetcher = ActiveFedora::Base::DescendantFetcher.new(ActiveFedora.fedora.base_uri, exclude_self: true)
     descendants = fetcher.descendant_and_self_uris
 
-    descendants.each_slice(chunk_size) do |uris|
+    descendants.each_slice(args.chunk_size) do |uris|
       ReindexChunkJob.perform_later(uris)
     end
   end

--- a/lib/tasks/remove_abstract_and_title_data.rake
+++ b/lib/tasks/remove_abstract_and_title_data.rake
@@ -69,7 +69,7 @@ namespace :scholars_archive do
           if orm.save
 
             logger.info "Graph saved successfully. Setting records abstract to be empty."
-            record.title = []
+            record.abstract = []
 
             logger.info "Saving record"
             record.save
@@ -79,7 +79,7 @@ namespace :scholars_archive do
         # If unordered abstracts to delete exist BUT there were no ordered abstracts
         elsif !record.resource.graph.query(abstract_statement).statements.empty? && record.resource.graph.query(nested_abstract_statement).statements.empty?
           logger.error "Skipping work #{record.id} because of missing abstract data"
-          logger.error "#{record.id}: #{record.resource.graph.query(abstract_statement).statements.count} ordered abstracts found"
+          logger.error "#{record.id}: #{record.resource.graph.query(abstract_statement).statements.count} abstracts found"
           logger.error "#{record.id}: #{record.resource.graph.query(nested_abstract_statement).statements.count} ordered abstracts found"
         end
       end

--- a/lib/tasks/update_conference_section_data.rake
+++ b/lib/tasks/update_conference_section_data.rake
@@ -1,6 +1,8 @@
 namespace :scholars_archive do
   desc "Update conference section preducate data from all work graphs"
-  task update_conference_section_data: :environment do
+  task :update_conference_section_data, [:chunk_size] => :environment do |t, args|
+    # Set a default value of 100 for chunk_size
+    args.with_defaults(:chunk_size => 100)
     datetime_today = Time.now.strftime('%Y%m%d%H%M%S') # "20171021125903"
     logger = ActiveSupport::Logger.new("#{Rails.root}/log/abstract-conference-section-#{datetime_today}.log")
     logger.info "Processing bulk changes for conference section"
@@ -22,39 +24,24 @@ namespace :scholars_archive do
     all_records << ::UndergraduateThesisOrProject.all
 
     logger.info "All works found. Searching for works to be updated"
+    to_update = {}
+    old_predicate = ::RDF::URI.new('https://w2id.org/scholarlydata/ontology/conference-ontology.owl#Track')
+
     all_records.each do |works|
-      works.each do |record|
-        old_conference_section_statement = [record.resource.rdf_subject, ::RDF::URI.new('https://w2id.org/scholarlydata/ontology/conference-ontology.owl#Track'), nil]
+      works.each_with_index do |record, index|
+        old_conference_section_statement = [record.resource.rdf_subject, old_predicate, nil]
 
         # If conference section to delete exist
         if !record.resource.graph.query(old_conference_section_statement).statements.empty?
           orm = Ldp::Orm.new(record.ldp_source)
           new_value = orm.query(old_conference_section_statement).first.object.value
 
-          logger.info ""
-          logger.info "Work found #{record.id}. Updating conference section"
-
-          logger.info "Setting to previous value: #{new_value}"
-          record.conference_section = new_value
-
-          logger.info "Saving record"
-          if record.save
-            logger.info "Work saved. Removing old conference section. Pulling graph from fedora"
-
-            logger.info "Deleting conference section from graph"
-            orm.graph.delete(old_conference_section_statement)
-
-            logger.info "Saving the graph"
-            if orm.save
-              logger.info "Graph saved successfully"
-            else
-              logger.error "Something went wrong with removing old value from graph #{record.id}"
-            end
-          else
-            logger.error "Something went wrong adding previous value #{record.id}"
-          end
+          to_update.merge!({ record.id => new_value })
         end
       end
+    end
+    to_update.each_slice(args.chunk_size) do |params|
+      ReplacePredicateJob.perform_later(params, old_predicate.to_s, 'conference_section')
     end
   end
 end

--- a/lib/tasks/update_conference_section_data.rake
+++ b/lib/tasks/update_conference_section_data.rake
@@ -1,0 +1,60 @@
+namespace :scholars_archive do
+  desc "Update conference section preducate data from all work graphs"
+  task update_conference_section_data: :environment do
+    datetime_today = Time.now.strftime('%Y%m%d%H%M%S') # "20171021125903"
+    logger = ActiveSupport::Logger.new("#{Rails.root}/log/abstract-conference-section-#{datetime_today}.log")
+    logger.info "Processing bulk changes for conference section"
+
+    logger.info "finding all works"
+    all_records = [::AdministrativeReportOrPublication.all]
+    all_records << ::Article.all
+    all_records << ::BatchUploadItem.all
+    all_records << ::ConferenceProceedingsOrJournal.all
+    all_records << ::Dataset.all
+    all_records << ::Default.all
+    all_records << ::EescPublication.all
+    all_records << ::GraduateProject.all
+    all_records << ::GraduateThesisOrDissertation.all
+    all_records << ::HonorsCollegeThesis.all
+    all_records << ::OpenEducationalResource.all
+    all_records << ::PurchasedEResource.all
+    all_records << ::TechnicalReport.all
+    all_records << ::UndergraduateThesisOrProject.all
+
+    logger.info "All works found. Searching for works to be updated"
+    all_records.each do |works|
+      works.each do |record|
+        old_conference_section_statement = [record.resource.rdf_subject, ::RDF::URI.new('https://w2id.org/scholarlydata/ontology/conference-ontology.owl#Track'), nil]
+
+        # If conference section to delete exist
+        if !record.resource.graph.query(old_conference_section_statement).statements.empty?
+          orm = Ldp::Orm.new(record.ldp_source)
+          new_value = orm.query(old_conference_section_statement).first.object.value
+
+          logger.info ""
+          logger.info "Work found #{record.id}. Updating conference section"
+
+          logger.info "Setting to previous value: #{new_value}"
+          record.conference_section = new_value
+
+          logger.info "Saving record"
+          if record.save
+            logger.info "Work saved. Removing old conference section. Pulling graph from fedora"
+
+            logger.info "Deleting conference section from graph"
+            orm.graph.delete(old_conference_section_statement)
+
+            logger.info "Saving the graph"
+            if orm.save
+              logger.info "Graph saved successfully"
+            else
+              logger.error "Something went wrong with removing old value from graph #{record.id}"
+            end
+          else
+            logger.error "Something went wrong adding previous value #{record.id}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will update the conference section predicate to use `w3id` rather than `w2id`. After merging we will want to quickly run `rake scholars_archive:update_conference_section_data` to update all the old values on all works to the new predicate.

supersedes #2282
Fixes #1781, #1782 