### PR TITLE
infrastructure tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,12 @@ RUN apk --no-cache update && apk --no-cache upgrade && \
   git sqlite sqlite-dev mysql mysql-client mysql-dev libressl libressl-dev \
   curl libc6-compat build-base tzdata zip autoconf automake libtool texinfo \
   bash bash-completion java-common openjdk11-jre-headless graphicsmagick \
-  ffmpeg openjpeg-dev openjpeg-tools openjpeg lcms2 lcms2-dev 
+  ffmpeg openjpeg-dev openjpeg-tools openjpeg lcms2 lcms2-dev py3-pip
 
 # Set the timezone to America/Los_Angeles (Pacific) then get rid of tzdata
 RUN cp -f /usr/share/zoneinfo/America/Los_Angeles /etc/localtime && \
-  echo 'America/Los_Angeles' > /etc/timezone
+  echo 'America/Los_Angeles' > /etc/timezone && \
+  pip install s3cmd
 
 # install libffi 3.2.1
 # https://github.com/libffi/libffi/archive/refs/tags/v3.2.1.tar.gz

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -1,0 +1,1 @@
+Yabeda::Rails.install!

--- a/config/prometheus_client.yml
+++ b/config/prometheus_client.yml
@@ -1,0 +1,3 @@
+# frozen_string_literal:true
+
+Prometheus::Client.config.data_store = Prometheus::Client::DataStores::DirectFileStore.new(dir: '/data/tmp/prom/prometheus_direct_file_store')


### PR DESCRIPTION
- enable prometheus_client gem Direct File Store via initializer
- enable yabeda-rails metrics via yabeda.rb initializer
- install py3-pip package and run `pip install s3cmd` to install `s3cmd` tool