### PR TITLE
Prepopulate the license only in Dataset

### DIFF
--- a/app/views/datasets/edit_fields/_license.html.erb
+++ b/app/views/datasets/edit_fields/_license.html.erb
@@ -1,0 +1,8 @@
+<%# OVERRIDE: Adding in custom License dropdown to automatically select the CC BY 4.0 for Dataset %>
+<% license_service = ScholarsArchive::LicenseService.new %>
+<%= f.input :license, as: :select,
+    collection: current_user.admin? ? license_service.select_sorted_all_options : license_service.select_active_options_from_model(f),
+    include_blank: true,
+    selected: "http://creativecommons.org/licenses/by/4.0/",
+    item_helper: license_service.method(:include_current_value),
+    input_html: { class: 'form-control' } %>


### PR DESCRIPTION
Adding in a new file to override the base license file to have it populate the copyright in the box in the dataset section only.