### PR TITLE
Update timedate format based on feedback

### DIFF
--- a/app/assets/stylesheets/osu.scss
+++ b/app/assets/stylesheets/osu.scss
@@ -523,6 +523,11 @@ ol.dd-list.dd-dragel {
   color: #808080;
 }
 
+.comment-line {
+  margin-top: -10px;
+  margin-bottom: 20px;
+}
+
 textarea.nested-field {
   min-height: 68px !important;
 }

--- a/app/assets/stylesheets/osu.scss
+++ b/app/assets/stylesheets/osu.scss
@@ -521,10 +521,10 @@ ol.dd-list.dd-dragel {
   font-size: 10px;
   font-style: italic;
   color: #808080;
+  margin-bottom: 0px;
 }
 
 .comment-line {
-  margin-top: -10px;
   margin-bottom: 20px;
 }
 

--- a/app/views/hyrax/base/_workflow_actions.html.erb
+++ b/app/views/hyrax/base/_workflow_actions.html.erb
@@ -34,7 +34,7 @@
             <%# Add in the datetime section into the comments %>
             <p class="comment-time"><%= comment.created_at.strftime("%B %-d, %Y - %l:%M %p") %></p>
             <%# Overridden to render the comment if it includes html %>
-            <dd><%= comment.comment.html_safe %></dd>
+            <dd class="comment-line"><%= comment.comment.html_safe %></dd>
           <% end %>
         </dl>
       </div>


### PR DESCRIPTION
Given feedback on the datetime, we formatted a way that differentiate between which comments belong under which comment.