### PR TITLE
Add in pre-selected Copyright

### DIFF
--- a/app/views/datasets/edit_fields/_rights_statement.html.erb
+++ b/app/views/datasets/edit_fields/_rights_statement.html.erb
@@ -1,0 +1,8 @@
+<%# OVERRIDE: Adding in custom Copyright statement to automatically select the (No Copyright - United States) for Dataset %>
+<% rights_statements = Hyrax.config.rights_statement_service_class.new %>
+<%= f.input :rights_statement,
+    collection: rights_statements.select_active_options,
+    include_blank: true,
+    selected: "http://rightsstatements.org/vocab/NoC-US/1.0/",
+    item_helper: rights_statements.method(:include_current_value),
+    input_html: { class: 'form-control' } %>


### PR DESCRIPTION
Add in the pre-select copyright statement to display "No Copyright - United States" as a pre selected option when filling out the datasets.