### PR TITLE
allow Sidekiq workers to fail gracefully

### DIFF
--- a/build/entrypoint-sidekiq.sh
+++ b/build/entrypoint-sidekiq.sh
@@ -28,12 +28,3 @@ fi
 timestamp=`date +'%Y-%m-%d %H:%M:%S'`
 echo "[$timestamp] Starting sidekiq ($RAILS_ENV)"
 RAILS_ENV=$RAILS_ENV bundle exec sidekiq -C $config_file
-
-timestamp=`date +'%Y-%m-%d %H:%M:%S'`
-echo "[$timestamp] Fell through sidekiq, starting life support systems."
-
-while `true`; do
-   timestamp=`date +'%Y-%m-%d %H:%M:%S'`
-   echo "[$timestamp] sleeping..."
-   sleep 30
-done


### PR DESCRIPTION
removed fallthrough loop from entrypoint-sidekiq.sh

when Sidekiq crashes, rather than allowing the container to die we still have the "fallthrough loop" in `entrypoint-sidekiq.sh`. Rather than exiting, the script goes into a while loop for debugging.

this PR removes the fallback loop