### PR TITLE
Filter out non-english labels if language is detectable

### DIFF
--- a/app/services/scholars_archive/triple_powered_service.rb
+++ b/app/services/scholars_archive/triple_powered_service.rb
@@ -63,6 +63,7 @@ module ScholarsArchive
       query.execute(graph).to_a
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def predicate_labels(graph)
       labels = {}
       return labels if graph.nil?
@@ -71,8 +72,8 @@ module ScholarsArchive
         eng_labels = graph
           .query(predicate: predicate)
           .select { |statement| !statement.is_a?(Array) }
-          .map { |statement| statement.object }
-          .select { |value| value.respond_to?(:language) ? value.language.in?(%i[en en-us]) : true  }
+          .map(&:object)
+          .select { |value| value.respond_to?(:language) ? value.language.in?(%i[en en-us]) : true }
 
         labels[predicate.to_s] = []
         labels[predicate.to_s] << eng_labels.map(&:to_s)
@@ -80,6 +81,7 @@ module ScholarsArchive
       end
       labels
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def rdf_label_predicates
       [

--- a/app/services/scholars_archive/triple_powered_service.rb
+++ b/app/services/scholars_archive/triple_powered_service.rb
@@ -68,11 +68,14 @@ module ScholarsArchive
       return labels if graph.nil?
 
       rdf_label_predicates.each do |predicate|
-        labels[predicate.to_s] = []
-        labels[predicate.to_s] << graph
+        eng_labels = graph
           .query(predicate: predicate)
           .select { |statement| !statement.is_a?(Array) }
-          .map { |statement| statement.object.to_s }
+          .map { |statement| statement.object }
+          .select { |value| value.respond_to?(:language) ? value.language.in?(%i[en en-us]) : true  }
+
+        labels[predicate.to_s] = []
+        labels[predicate.to_s] << eng_labels.map(&:to_s)
         labels[predicate.to_s].flatten!.compact!
       end
       labels


### PR DESCRIPTION
Fixes #2492 by only selecting the labels that are either English or US-English, if the language can be determined