### PR TITLE
Prevent fileset page from displaying if parent is in workflow

### DIFF
--- a/config/initializers/hacks/hyrax_file_sets_controller_hack.rb
+++ b/config/initializers/hacks/hyrax_file_sets_controller_hack.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal:true
+
+Rails.application.config.to_prepare do
+  Hyrax::FileSetsController.class_eval do
+
+    def show
+      # Prevent fileset page from displaying if parent work is still in workflow
+      if presenter.parent.solr_document.suppressed?
+        flash[:notice] = "The item you tried to access is unavailable"
+        redirect_to '/'
+        return if presenter.parent.solr_document.suppressed?
+      end
+      # Original Hyrax response
+      respond_to do |wants|
+        wants.html { presenter }
+        wants.json { presenter }
+        additional_response_formats(wants)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1706 