### PR TITLE
Add in a filter to not collect admin visit

### DIFF
--- a/app/controllers/concerns/scholars_archive/download_analytics_behavior.rb
+++ b/app/controllers/concerns/scholars_archive/download_analytics_behavior.rb
@@ -9,7 +9,8 @@ module ScholarsArchive
       after_action :track_download, only: :show
 
       def track_download
-        unless Hyrax.config.google_analytics_id.blank? || params[:file].to_s.downcase == 'thumbnail'
+        # Add in special case to ignore collection of analytic data
+        unless Hyrax.config.google_analytics_id.blank? || params[:file].to_s.downcase == 'thumbnail' || request.path.include?('/admin/')
           # Staccato works with Google Analytics v1 api:
           # https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
           # Staccato on Github: https://github.com/tpitale/staccato


### PR DESCRIPTION
Add in a special case to ignore some admin path visit to not be collected in the `GA4`. 