### PR TITLE
Update OAI config from http to https

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -621,7 +621,7 @@ class CatalogController < ApplicationController
     config.oai = {
       provider: {
         repository_name: 'ScholarsArchive@OSU',
-        repository_url: 'http://ir.library.oregonstate.edu',
+        repository_url: 'https://ir.library.oregonstate.edu',
         record_prefix: 'ir.library.oregonstate.edu',
         admin_email: 'scholarsarchive@oregonstate.edu'
       },

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -380,7 +380,7 @@ RSpec.describe SolrDocument do
                                          'has_model_ssim' => ['Default'],
                                          'id' => ['xw42n789j']
                                        })
-        expect(document.oai_identifier).to eq 'http://ir.library.oregonstate.edu/concern/defaults/xw42n789j'
+        expect(document.oai_identifier).to eq 'https://ir.library.oregonstate.edu/concern/defaults/xw42n789j'
       end
     end
   end


### PR DESCRIPTION
`UPDATE:`  Add in the update to fix the `config.oai` to set the `basedURL` to reflect the `https` rather than the `http`.