### PR TITLE
Update Peer Review Ontology

### DIFF
--- a/app/models/administrative_report_or_publication.rb
+++ b/app/models/administrative_report_or_publication.rb
@@ -20,6 +20,6 @@ class AdministrativeReportOrPublication < ActiveFedora::Base
   private
 
   def set_defaults
-    self.peerreviewed ||= 'FALSE'
+    self.peerreviewed ||= 'false'
   end
 end

--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -244,7 +244,7 @@ module ScholarsArchive
         index.as :stored_searchable
       end
 
-      property :peerreviewed, predicate: ::RDF::URI('http://dbpedia.org/ontology/isPeerReviewed'), multiple: false do |index|
+      property :peerreviewed, predicate: ::RDF::URI('https://dbpedia.org/ontology/isPeerReviewed'), multiple: false do |index|
         index.as :stored_searchable, :facetable
       end
 

--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -244,7 +244,7 @@ module ScholarsArchive
         index.as :stored_searchable
       end
 
-      property :peerreviewed, predicate: ::RDF::URI('http://purl.org/ontology/bibo/peerReviewed'), multiple: false do |index|
+      property :peerreviewed, predicate: ::RDF::URI('http://dbpedia.org/ontology/isPeerReviewed'), multiple: false do |index|
         index.as :stored_searchable, :facetable
       end
 

--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -244,7 +244,7 @@ module ScholarsArchive
         index.as :stored_searchable
       end
 
-      property :peerreviewed, predicate: ::RDF::URI('https://dbpedia.org/ontology/isPeerReviewed'), multiple: false do |index|
+      property :peerreviewed, predicate: ::RDF::URI('http://dbpedia.org/ontology/isPeerReviewed'), multiple: false do |index|
         index.as :stored_searchable, :facetable
       end
 

--- a/app/models/conference_proceedings_or_journal.rb
+++ b/app/models/conference_proceedings_or_journal.rb
@@ -23,6 +23,6 @@ class ConferenceProceedingsOrJournal < ActiveFedora::Base
   private
 
   def set_defaults
-    self.peerreviewed ||= 'FALSE'
+    self.peerreviewed ||= 'false'
   end
 end

--- a/app/models/graduate_project.rb
+++ b/app/models/graduate_project.rb
@@ -24,6 +24,6 @@ class GraduateProject < ActiveFedora::Base
   private
 
   def set_defaults
-    self.peerreviewed ||= 'FALSE'
+    self.peerreviewed ||= 'false'
   end
 end

--- a/app/models/graduate_thesis_or_dissertation.rb
+++ b/app/models/graduate_thesis_or_dissertation.rb
@@ -24,6 +24,6 @@ class GraduateThesisOrDissertation < ActiveFedora::Base
   private
 
   def set_defaults
-    self.peerreviewed ||= 'FALSE'
+    self.peerreviewed ||= 'false'
   end
 end

--- a/app/models/honors_college_thesis.rb
+++ b/app/models/honors_college_thesis.rb
@@ -28,6 +28,6 @@ class HonorsCollegeThesis < ActiveFedora::Base
     self.resource_type = ['Honors College Thesis'] if resource_type.empty?
     self.other_affiliation = ['http://opaquenamespace.org/ns/subject/OregonStateUniversityHonorsCollege'] if other_affiliation.empty?
     self.degree_level ||= "Bachelor's"
-    self.peerreviewed ||= 'FALSE'
+    self.peerreviewed ||= 'false'
   end
 end

--- a/app/models/technical_report.rb
+++ b/app/models/technical_report.rb
@@ -21,6 +21,6 @@ class TechnicalReport < ActiveFedora::Base
   private
 
   def set_defaults
-    self.peerreviewed ||= 'FALSE'
+    self.peerreviewed ||= 'false'
   end
 end

--- a/app/models/undergraduate_thesis_or_project.rb
+++ b/app/models/undergraduate_thesis_or_project.rb
@@ -26,6 +26,6 @@ class UndergraduateThesisOrProject < ActiveFedora::Base
 
   def set_defaults
     self.degree_level ||= "Bachelor's"
-    self.peerreviewed ||= 'FALSE'
+    self.peerreviewed ||= 'false'
   end
 end

--- a/config/authorities/peerreviewed.yml
+++ b/config/authorities/peerreviewed.yml
@@ -1,7 +1,7 @@
 terms:
-- id: "TRUE"
+- id: "true"
   term: "Yes"
   active: true
-- id: "FALSE"
+- id: "false"
   term: "No"
   active: true

--- a/lib/tasks/update_peer_reviewed_data.rake
+++ b/lib/tasks/update_peer_reviewed_data.rake
@@ -1,0 +1,61 @@
+namespace :scholars_archive do
+  desc "Update peer review predicate data from all work graphs & change value to lowercase"
+  task :update_peer_review_data, [:chunk_size] => :environment do |t, args|
+    # SETUP: Setup a default value of 100 for chunk_size
+    args.with_defaults(:chunk_size => 100)
+
+    # SETUP: Add in the start time of the bulk changes and add message to know that the rake is starting
+    datetime_today = Time.now.strftime('%Y%m%d%H%M%S') # "20171021125903"
+    Rails.logger.info "Processing bulk changes for peer review"
+
+    # ADD: Add in all the works that are in production to an array
+    Rails.logger.info "Finding all the works..."
+    all_records = [::AdministrativeReportOrPublication.all]
+    all_records << ::Article.all
+    all_records << ::BatchUploadItem.all
+    all_records << ::ConferenceProceedingsOrJournal.all
+    all_records << ::Dataset.all
+    all_records << ::Default.all
+    all_records << ::EescPublication.all
+    all_records << ::GraduateProject.all
+    all_records << ::GraduateThesisOrDissertation.all
+    all_records << ::HonorsCollegeThesis.all
+    all_records << ::OpenEducationalResource.all
+    all_records << ::PurchasedEResource.all
+    all_records << ::TechnicalReport.all
+    all_records << ::UndergraduateThesisOrProject.all
+
+    # SEARCHING: After all the works are added, search for the one that has the old predicate
+    Rails.logger.info "All works found. Searching for works to be updated"
+    old_predicate = ::RDF::URI.new('http://purl.org/ontology/bibo/peerReviewed')
+
+    # LOOP: Now loop through each works and identify the work that needed to be updated
+    all_records.each do |works|
+      works.each do |record|
+        # FETCH: Get the old peer review from the work
+        old_peer_review_statement = [record.resource.rdf_subject, old_predicate, nil]
+
+        # CONDITION: If the peer review section found in work, add it to the hash of 'to_update'
+        if !record.resource.graph.query(old_peer_review_statement).statements.empty?
+          # GET: Get the graph
+          orm = Ldp::Orm.new(record.ldp_source)
+          new_value = orm.query(old_peer_review_statement).first.object.value.downcase
+          statement = [orm.resource.subject_uri, old_predicate, nil]
+
+          # DELETE: Delete the graph
+          orm.graph.delete(statement)
+
+          # CHECK: Now save the works and update the value to lowercase
+          if orm.save
+            logger.info "Deleted statement from Fedora: #{statement}"
+            logger.info "Setting the value to lowercase"
+            record.peerreviewed = new_value
+            record&.save
+          else
+            logger.info "Failed to delete statement from Fedora: #{statement}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/update_peer_reviewed_data.rake
+++ b/lib/tasks/update_peer_reviewed_data.rake
@@ -32,11 +32,11 @@ namespace :scholars_archive do
         # FETCH: Get the old peer review from the work
         old_peer_review_statement = [record.resource.rdf_subject, old_predicate, nil]
 
-        # CONDITION: If the peer review section found in work, add it to the hash of 'to_update'
+        # CONDITION: If the peer review section found in work, get the info out for preparing to be delete
         if !record.resource.graph.query(old_peer_review_statement).statements.empty?
           # GET: Get the graph
           orm = Ldp::Orm.new(record.ldp_source)
-          new_value = orm.query(old_peer_review_statement).first.object.value.downcase
+          new_update_value = record.peerreviewed.downcase
           statement = [orm.resource.subject_uri, old_predicate, nil]
 
           # DELETE: Delete the graph
@@ -46,7 +46,7 @@ namespace :scholars_archive do
           if orm.save
             logger.info "Deleted statement from Fedora: #{statement}"
             logger.info "Setting the value to lowercase"
-            record.peerreviewed = new_value
+            record.peerreviewed = new_update_value
             record&.save
           else
             logger.info "Failed to delete statement from Fedora: #{statement}"

--- a/lib/tasks/update_peer_reviewed_data.rake
+++ b/lib/tasks/update_peer_reviewed_data.rake
@@ -1,9 +1,6 @@
 namespace :scholars_archive do
   desc "Update peer review predicate data from all work graphs & change value to lowercase"
-  task :update_peer_review_data, [:chunk_size] => :environment do |t, args|
-    # SETUP: Setup a default value of 100 for chunk_size
-    args.with_defaults(:chunk_size => 100)
-
+  task update_peer_review_data: :environment do
     # SETUP: Add in the start time of the bulk changes and add message to know that the rake is starting
     datetime_today = Time.now.strftime('%Y%m%d%H%M%S') # "20171021125903"
     Rails.logger.info "Processing bulk changes for peer review"

--- a/lib/tasks/update_peer_reviewed_data.rake
+++ b/lib/tasks/update_peer_reviewed_data.rake
@@ -36,7 +36,7 @@ namespace :scholars_archive do
         if !record.resource.graph.query(old_peer_review_statement).statements.empty?
           # GET: Get the graph
           orm = Ldp::Orm.new(record.ldp_source)
-          new_update_value = record.peerreviewed.downcase
+          new_update_value = orm.query(old_peer_review_statement).first.object.value.downcase
           statement = [orm.resource.subject_uri, old_predicate, nil]
 
           # DELETE: Delete the graph

--- a/spec/services/scholars_archive/peerreviewed_service_spec.rb
+++ b/spec/services/scholars_archive/peerreviewed_service_spec.rb
@@ -7,7 +7,7 @@ describe ScholarsArchive::PeerreviewedService do
 
   describe '#select_active_options' do
     it 'returns active terms' do
-      expect(service.select_active_options).to include(%w[Yes TRUE], %w[No FALSE])
+      expect(service.select_active_options).to include(%w[Yes true], %w[No false])
     end
   end
 end


### PR DESCRIPTION
`UDPATE:` Make an adjustment to the ontology of the `peer review` subject term and updated to a new URI predicate and other areas that uses the old ontology.