### PR TITLE
Check for response to #alpha_channel= when characterizing filesets

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -32,7 +32,7 @@ class CharacterizeJob < Hyrax::ApplicationJob
 
     characterization_service.run(file_set.characterization_proxy, filepath)
     Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
-    file_set.characterization_proxy.alpha_channels = channels(filepath) if file_set.image? && Hyrax.config.iiif_image_server?
+    file_set.characterization_proxy.alpha_channels = channels(filepath) if file_set.image? && Hyrax.config.iiif_image_server? && file_set.characterization_proxy.respond_to(:alpha_channels=)
     file_set.characterization_proxy.save!
 
     # Ensure that if the actual file content has changed, the mod timestamp on the FileSet object changes.


### PR DESCRIPTION
Fixes #2531 