### PR TITLE
Update to clean up overridden controller

### DIFF
--- a/config/initializers/hacks/hyrax_file_sets_controller_hack.rb
+++ b/config/initializers/hacks/hyrax_file_sets_controller_hack.rb
@@ -1,86 +1,17 @@
 # frozen_string_literal:true
 
-  Hyrax::FileSetsController.class_eval do
-
-    prepend_before_action :redirect_if_restricted, only: :show
-
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/MethodLength
-      def redirect_if_restricted
-        curation_concern = ActiveFedora::Base.find(params[:id])
-
-        # Reset flash notice since we redirected due to not viewable
-        flash[:alert] = ''
-
-        # First we check if the user can see the work or fileset
-        return unless cannot?(:read, curation_concern) && (curation_concern.embargo_id.present? || curation_concern.visibility == 'authenticated')
-
-        # Next we check if user got here specifically from the homepage. This means they got redirected and clicked the login link.
-        return if request.referrer.to_s == "https://#{ENV.fetch('SCHOLARSARCHIVE_URL_HOST')}/"
-
-        # Otherwise, this returns them to the homepage because they got here from elsewhere and need to know this work is embargoed
-        # and if its OSU visible, provided a link to login and continue to where they were going
-        if curation_concern.embargo_id.present?
-          case curation_concern.embargo.visibility_during_embargo
-          when 'restricted'
-            flash[:notice] = "The item you are trying to access is under embargo until #{curation_concern.embargo.embargo_release_date.strftime('%B')} #{curation_concern.embargo.embargo_release_date.day}, #{curation_concern.embargo.embargo_release_date.year}."
-          when 'authenticated'
-            flash[:notice] = "The item you are trying to access is under embargo until #{curation_concern.embargo.embargo_release_date.strftime('%B')} #{curation_concern.embargo.embargo_release_date.day}, #{curation_concern.embargo.embargo_release_date.year}. However, users with an OSU login (ONID) may log in to view the item. #{helpers.link_to 'Click here to login and continue to your work', request.original_url}"
-          end
-        else
-          flash[:notice] = "The item you are trying to access is limited to OSU users only. Users with an OSU login (ONID) may log in to view the item. #{helpers.link_to 'Click here to login and continue to your work', request.original_url}"
-        end
-        redirect_to '/'
-      end
-      # rubocop:enable Metrics/CyclomaticComplexity
-      # rubocop:enable Metrics/MethodLength
+Hyrax::FileSetsController.class_eval do
+  include ScholarsArchive::RedirectIfRestrictedBehavior
     
+  prepend_before_action :redirect_if_unavailable, only: :show
+  prepend_before_action :redirect_if_restricted, only: :show
 
-    def show
-      Rails.logger.info "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-      Rails.logger.info "Hello World"
-      curation_concern = presenter.solr_document.id
-
-      Rails.logger.info "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-      Rails.logger.info "Hello World 2"
-      # Reset flash notice since we redirected due to not viewable
-      flash[:alert] = ''
-
-      Rails.logger.info "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-      Rails.logger.info "Hello World 3"
-      # First we check if the user can see the work or fileset
-      return unless cannot?(:read, curation_concern) && (curation_concern.embargo_id.present? || curation_concern.visibility == 'authenticated')
-
-      Rails.logger.info "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-      Rails.logger.info "Hello World 4"
-      # Next we check if user got here specifically from the homepage. This means they got redirected and clicked the login link.
-      return if request.referrer.to_s == "https://#{ENV.fetch('SCHOLARSARCHIVE_URL_HOST')}/"
-
-      Rails.logger.info "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-      Rails.logger.info "Hello World 5"
-      # Otherwise, this returns them to the homepage because they got here from elsewhere and need to know this work is embargoed
-      # and if its OSU visible, provided a link to login and continue to where they were going
-      if curation_concern.embargo_id.present?
-        case curation_concern.embargo.visibility_during_embargo
-        when 'restricted'
-          flash[:notice] = "The item you are trying to access is under embargo until #{curation_concern.embargo.embargo_release_date.strftime('%B')} #{curation_concern.embargo.embargo_release_date.day}, #{curation_concern.embargo.embargo_release_date.year}."
-        when 'authenticated'
-          flash[:notice] = "The item you are trying to access is under embargo until #{curation_concern.embargo.embargo_release_date.strftime('%B')} #{curation_concern.embargo.embargo_release_date.day}, #{curation_concern.embargo.embargo_release_date.year}. However, users with an OSU login (ONID) may log in to view the item. #{helpers.link_to 'Click here to login and continue to your work', request.original_url}"
-        end
-      else
-        flash[:notice] = "The item you are trying to access is limited to OSU users only. Users with an OSU login (ONID) may log in to view the item. #{helpers.link_to 'Click here to login and continue to your work', request.original_url}"
-      end
-      # Prevent fileset page from displaying if parent work is still in workflow
-      if presenter.parent.solr_document.suppressed? && !current_user&.admin?
-        flash[:notice] = "The item you tried to access is unavailable because it is in the review process."
-        redirect_to '/'
-        return if presenter.parent.solr_document.suppressed?
-      end
-      # Original Hyrax response
-      respond_to do |wants|
-        wants.html { presenter }
-        wants.json { presenter }
-        additional_response_formats(wants)
-      end
+  def redirect_if_unavailable
+    # Prevent fileset page from displaying if parent work is still in workflow
+    if presenter.parent.solr_document.suppressed? && !current_user&.admin?
+      flash[:notice] = "The item you tried to access is unavailable because it is in the review process."
+      redirect_to '/'
+      return if presenter.parent.solr_document.suppressed?
     end
   end
+end


### PR DESCRIPTION
This refactors to remove the overridden show method from FileSetsController. Its not needed if we just write a new method and prepend it in a before action.

This also prepends two methods. One being the redirect if restricted behavior and the second being the "unavailable" redirect. The first one to fire will be the redirect if restricted. If that one doesnt go through then the next one will. that should catch all the redirects for the filesets. If both fail then it'll flow naturally through the show action.