### PR TITLE
Sarah's update to other_affiliation.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,4 +243,5 @@ workflows:
                 - main
                 - /infra\/.*/
                 - /staging\/.*/
+                - /patch\/.*/
           repo: sa_web

--- a/config/authorities/other_affiliation.yml
+++ b/config/authorities/other_affiliation.yml
@@ -149,3 +149,6 @@ terms:
 - id: "https://opaquenamespace.org/ns/subject/OregonStateUniversityOfficeOfUndergraduateResearch"
   term: "Office of Undergraduate Research (OUR)"
   active: true
+- id: "http://opaquenamespace.org/ns/subject/OregonStateUniversitySpringPosterSymposium"
+  term: "Spring Poster Symposium (SPS)"
+  active: true


### PR DESCRIPTION
@simholt we won't be to deploy #2651 until #2549 is QA'd. I'm opening a new PR to allow us to build temporary patches based on other points of history and I'm applying your fix. We can have a temp deploy w/o #2549 until it's QA'd