### PR TITLE
Added in new ROR search to funding body

### DIFF
--- a/.rubocop_fix_me.yml
+++ b/.rubocop_fix_me.yml
@@ -982,7 +982,7 @@ Style/MethodDefParentheses:
 Lint/UriEscapeUnescape:
   Exclude:
     - "lib/qa/authorities/geonames.rb"
-    - "app/authorities/qa/authorities/research_organization_registry.rb"
+    - "lib/qa/authorities/research_organization_registry.rb"
 
 Capybara/VisibilityMatcher:
   Exclude:

--- a/.rubocop_fix_me.yml
+++ b/.rubocop_fix_me.yml
@@ -979,11 +979,6 @@ Style/MethodDefParentheses:
   Exclude:
     - "lib/scholars_archive/document/qualified_dublin_core.rb"
 
-Lint/UriEscapeUnescape:
-  Exclude:
-    - "lib/qa/authorities/geonames.rb"
-    - "lib/qa/authorities/research_organization_registry.rb"
-
 Capybara/VisibilityMatcher:
   Exclude:
     - "spec/views/records/edit_fields/_degree_field.html.erb_spec.rb"

--- a/.rubocop_fix_me.yml
+++ b/.rubocop_fix_me.yml
@@ -1011,6 +1011,10 @@ RSpec/RepeatedExampleGroupDescription:
     - "spec/models/default_spec.rb"
     - "spec/scholars_archive/validators/graduation_year_validator_spec.rb"
 
+RSpec/UnspecifiedException:
+  Exclude:
+    - "spec/services/scholars_archive/research_organization_registry_service_spec.rb"
+
 Lint/RedundantCopDisableDirective:
   Exclude:
     - "app/indexers/concerns/scholars_archive/indexes_combined_sort_date.rb"

--- a/.rubocop_fix_me.yml
+++ b/.rubocop_fix_me.yml
@@ -982,6 +982,7 @@ Style/MethodDefParentheses:
 Lint/UriEscapeUnescape:
   Exclude:
     - "lib/qa/authorities/geonames.rb"
+    - "app/authorities/qa/authorities/research_organization_registry.rb"
 
 Capybara/VisibilityMatcher:
   Exclude:

--- a/app/assets/javascripts/hyrax/autocomplete.es6
+++ b/app/assets/javascripts/hyrax/autocomplete.es6
@@ -1,0 +1,64 @@
+import Default from './autocomplete/default'
+import Resource from './autocomplete/resource'
+import LinkedData from './autocomplete/linked_data'
+
+// OVERRIDE: Add in new field to the autocomplete form
+export default class Autocomplete {
+  /**
+   * Setup for the autocomplete field.
+   * @param {jQuery} element - The input field to add autocompete to
+   * @param {string} fieldName - The name of the field (e.g. 'based_near')
+   * @param {string} url - The url for the autocompete search endpoint
+   */
+  setup (element, fieldName, url) {
+    if(element.data('autocomplete-type') && element.data('autocomplete-type').length > 0) {
+      this.byDataAttribute(element, url)
+    } else {
+      this.byFieldName(element, fieldName, url)
+    }
+  }
+
+  byDataAttribute(element, url) {
+    let type = element.data('autocomplete-type')
+    let exlude = element.data('exclude-work')
+    if(type === 'resource' && exclude.length > 0) {
+      new Resource(
+        element,
+        url,
+        { excluding: exclude }
+      )
+    } else if(type === 'resource' ) {
+      new Resource(
+        element,
+        url)
+    } else if(type === 'linked') {
+      new LinkedData(element, url)
+    } else {
+      new Default(element, url)
+    }
+  }
+
+  byFieldName(element, fieldName, url) {
+    switch (fieldName) {
+      case 'work':
+        new Resource(
+          element,
+          url,
+          { excluding: element.data('exclude-work') }
+        )
+        break
+      case 'collection':
+        new Resource(
+          element,
+          url)
+        break
+      // ADD: Add case for 'funding_body' on autocomplete
+      case 'funding_body':
+      case 'based_near':
+        new LinkedData(element, url)
+      default:
+        new Default(element, url)
+        break
+    }
+  }
+}

--- a/app/authorities/qa/authorities/research_organization_registry.rb
+++ b/app/authorities/qa/authorities/research_organization_registry.rb
@@ -10,7 +10,8 @@ module Qa::Authorities
 
     # SELF METHOD: Format the label to present on typeahead
     self.label = lambda do |item|
-      [item['names'].map { |v| v['value'] if v['types'].include?('ror_display') }, "(#{item['id']})"].compact.join(', ')
+      val = item['names'].map { |v| v['value'] if v['types'].include?('ror_display') }.compact
+      [val.first, "(#{item['id']})"].compact.join(', ')
     end
 
     # METHOD: Create a search function based on user typing

--- a/app/authorities/qa/authorities/research_organization_registry.rb
+++ b/app/authorities/qa/authorities/research_organization_registry.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Qa::Authorities
+  # CLASS: Research Organization Registry
+  class ResearchOrganizationRegistry < Qa::Authorities::Base
+    include WebServiceBase
+
+    # ATTRIBUTE: Add a :label class attribute
+    class_attribute :label
+
+    # SELF METHOD: Format the label to present on typeahead
+    self.label = lambda do |item|
+      [item['names'].map { |v| v['value'] if v['types'].include?('ror_display') }, "(#{item['id']})"].compact.join(', ')
+    end
+
+    # METHOD: Create a search function based on user typing
+    def search(query)
+      # CONDITION: Check if user search by 'id' or 'word'
+      if query[0] == '0' && query.length == 9
+        parse_authority_response_with_id(json(build_id_url(query)))
+      else
+        parse_authority_response(json(build_query_url(query)))
+      end
+    end
+
+    # METHOD: To double check the 'q' string for special char
+    def untaint(query)
+      query.gsub(/[^\w\s-]/, '')
+    end
+
+    # METHOD: Build search using 'word'
+    def build_query_url(query)
+      query_str = URI.escape(untaint(query))
+      "https://api.ror.org/v2/organizations?query=#{query_str}"
+    end
+
+    # METHOD: Create a search using id number instead
+    def build_id_url(query)
+      query_str = URI.escape(untaint(query))
+      "https://api.ror.org/v2/organizations/#{query_str}"
+    end
+
+    private
+
+    # PARSE: Reformats the data received from the service
+    def parse_authority_response(response)
+      response['items'].map do |result|
+        { 'id' => result['id'].to_s,
+          'label' => label.call(result) }
+      end
+    end
+
+    # REFORMAT: Format data with the id given
+    def parse_authority_response_with_id(response)
+      [{ 'id' => response['id'].to_s,
+         'label' => label.call(response) }]
+    end
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -93,7 +93,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('degree_level', :facetable), limit: 5, label: 'Degree Level'
     config.add_facet_field solr_name('degree_name', :facetable), limit: 5, label: 'Degree Name'
     config.add_facet_field solr_name('file_format', :facetable), label: 'File Format', limit: 5
-    config.add_facet_field solr_name('funding_body', :facetable), label: 'Funding Body', limit: 5
+    config.add_facet_field solr_name('funding_body_label', :facetable), label: 'Funding Body', limit: 5
     config.add_facet_field 'has_journal_sfacet', limit: 5, label: 'Journal Title'
     config.add_facet_field 'language_label_ssim', label: 'Language', limit: 5
     config.add_facet_field 'license_label_ssim', label: 'License', limit: 5

--- a/app/controllers/concerns/scholars_archive/works_controller_behavior.rb
+++ b/app/controllers/concerns/scholars_archive/works_controller_behavior.rb
@@ -78,31 +78,14 @@ module ScholarsArchive
 
     # METHOD: Manually add controlled_vocab object to funding body
     def store_funding
-      # FETCH: Get the attributes from params, setup a tmp array, & get object if exist in curation_concern
-      funding_params = params[hash_key_for_curation_concern]['funding_body_attributes']
-      funding_current = curation_concern.funding_body.blank? ? [] : curation_concern.funding_body
-      tmp_arr = []
-
       # LOOP: Loop through each entry from attribute(s)
-      funding_params.each do |_key, value|
-        # CREATE & CHECK: Setup a exist tracker to see if already exist in work & skip if 'id' value is blank
-        exist_tracker = 0
+      curation_concern.funding_body = params[hash_key_for_curation_concern]['funding_body_attributes'].to_unsafe_h.each_with_object([]) do |(_key, value), object|
+        # CHECK: Skip if 'id' value is blank or destroy
         next if value['id'].blank? || value['_destroy'] == 'true'
 
-        # LOOP: Check the current funding to see if any exist so we don't have to create a new 'cv'
-        funding_current.each do |current|
-          if current.id == value['id']
-            tmp_arr << current
-            exist_tracker = 1
-          end
-        end
-
-        # CONDITION: If no 'id' match current, then create a new 'cv'
-        tmp_arr << ScholarsArchive::ControlledVocabularies::ResearchOrganizationRegistry.new(value['id']) if exist_tracker.zero?
+        # STORE: Store the controlled_vocab obj into the array
+        object << ScholarsArchive::ControlledVocabularies::ResearchOrganizationRegistry.new(value['id'])
       end
-
-      # RETURN: Assign the obj arrays into the funding_body area
-      curation_concern.funding_body = tmp_arr.flatten
     end
 
     # METHOD: Create a method to fetch individual file set

--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -300,7 +300,7 @@ module ScholarsArchive
       attr_accessor :current_username
 
       class_attribute :controlled_properties
-      self.controlled_properties = [:based_near]
+      self.controlled_properties = [:based_near, :funding_body]
     end
   end
 end

--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -167,7 +167,8 @@ module ScholarsArchive
         index.as :stored_searchable, :facetable
       end
 
-      property :funding_body, predicate: ::RDF::Vocab::MARCRelators.fnd do |index|
+      # UPDATE: Add in the class name for 'controlled_vocab' to the funding_body
+      property :funding_body, predicate: ::RDF::Vocab::MARCRelators.fnd, class_name: ScholarsArchive::ControlledVocabularies::ResearchOrganizationRegistry do |index|
         index.as :stored_searchable, :facetable
       end
 

--- a/app/models/concerns/scholars_archive/default_metadata.rb
+++ b/app/models/concerns/scholars_archive/default_metadata.rb
@@ -300,7 +300,7 @@ module ScholarsArchive
       attr_accessor :current_username
 
       class_attribute :controlled_properties
-      self.controlled_properties = [:based_near, :funding_body]
+      self.controlled_properties = %i[based_near funding_body]
     end
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -89,6 +89,11 @@ class SolrDocument
     self['embargo_date_range_ssim']
   end
 
+  # METHOD: A funding_body fetching label method
+  def funding_body_label
+    ScholarsArchive::LabelParserService.parse_label_uris(self['funding_body_linked_ssim']) || []
+  end
+
   def nested_geo
     self['nested_geo_label_ssim'] || []
   end

--- a/app/presenters/concerns/scholars_archive/default_presenter_behavior.rb
+++ b/app/presenters/concerns/scholars_archive/default_presenter_behavior.rb
@@ -23,6 +23,7 @@ module ScholarsArchive
                :other_affiliation_label,
                :peerreviewed_label,
                :based_near_linked_label,
+               :funding_body_label,
                :rights_statement_label, to: :solr_document
       delegate(*::ScholarsArchive::DefaultTerms.base_terms, to: :solr_document)
     end

--- a/app/services/scholars_archive/research_organization_registry_service.rb
+++ b/app/services/scholars_archive/research_organization_registry_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ScholarsArchive
+  # SERVICE: Add in class for ROR Service
+  class ResearchOrganizationRegistryService < ::Qa::Authorities::ResearchOrganizationRegistry
+    CACHE_KEY_PREFIX = 'scholars_archive_ror_label-v1-'
+    CACHE_EXPIRATION = 1.week
+
+    def full_label(uri)
+      return if uri.blank?
+
+      id = extract_id uri
+      Rails.cache.fetch(cache_key(id), expires_in: CACHE_EXPIRATION) do
+        search_term = search(id)
+        return search_term.first['label']
+      end
+    rescue URI::InvalidURIError
+      # Old data may be just a string, display it.
+      uri
+    end
+
+    private
+
+    def extract_id(obj)
+      uri = case obj
+            when String
+              URI(obj)
+            when URI
+              obj
+            else
+              raise ArgumentError, "#{obj} is not a valid type"
+            end
+      uri.path.split('/').last
+    end
+
+    def cache_key(id)
+      "#{CACHE_KEY_PREFIX}#{id}"
+    end
+  end
+end

--- a/app/services/scholars_archive/research_organization_registry_service.rb
+++ b/app/services/scholars_archive/research_organization_registry_service.rb
@@ -11,8 +11,7 @@ module ScholarsArchive
 
       id = extract_id uri
       Rails.cache.fetch(cache_key(id), expires_in: CACHE_EXPIRATION) do
-        search_term = search(id)
-        return search_term.first['label']
+        label.call(find(id))
       end
     rescue URI::InvalidURIError
       # Old data may be just a string, display it.

--- a/app/services/scholars_archive/research_organization_registry_service.rb
+++ b/app/services/scholars_archive/research_organization_registry_service.rb
@@ -6,6 +6,7 @@ module ScholarsArchive
     CACHE_KEY_PREFIX = 'scholars_archive_ror_label-v1-'
     CACHE_EXPIRATION = 1.week
 
+    # All method follow the exact same layout on how Hyrax::LocationService works
     def full_label(uri)
       return if uri.blank?
 

--- a/app/views/records/edit_fields/_funding_body.html.erb
+++ b/app/views/records/edit_fields/_funding_body.html.erb
@@ -1,0 +1,13 @@
+<%# OVERRIDE: Override the edit field for 'funding_body' to have autocomplete field %>
+<%= f.input key,
+            as: :controlled_vocabulary,
+            placeholder: 'Search for a funding body',
+            input_html: {
+              class: 'form-control',
+              data: { 'autocomplete-url' => "/authorities/search/research_organization_registry",
+                      'autocomplete' => key }
+            },
+            ### Required for the ControlledVocabulary javascript:
+            wrapper_html: { data: { 'autocomplete-url' => "/authorities/search/research_organization_registry",
+                                    'field-name' => key }},
+            required: f.object.required?(key) %>

--- a/app/workers/fetch_failed_graph_worker.rb
+++ b/app/workers/fetch_failed_graph_worker.rb
@@ -5,7 +5,7 @@ class FetchFailedGraphWorker
   include Sidekiq::Worker
   sidekiq_options retry: 11
 
-  def perform(pid, val, _controlled_prop)
+  def perform(pid, val, controlled_prop)
     work = ActiveFedora::Base.find(pid)
     solr_doc = work.to_solr
 
@@ -14,7 +14,11 @@ class FetchFailedGraphWorker
       val.persist!
     end
 
-    solr_based_near_linked_insert(solr_doc, val)
+    if controlled_prop.to_s == 'based_near'
+      solr_based_near_linked_insert(solr_doc, val)
+    else
+      solr_funding_body_linked_insert(solr_doc, val)
+    end
 
     ActiveFedora::SolrService.add(solr_doc)
     ActiveFedora::SolrService.commit
@@ -24,6 +28,12 @@ class FetchFailedGraphWorker
     solr_doc['based_near_linked_tesim'] = [val.solrize.last.is_a?(String) ? val.solrize.last : val.solrize.last[:label].split('$').first]
     solr_doc['based_near_linked_ssim'] = [val.solrize.last.is_a?(String) ? val.solrize.last : val.solrize.last[:label].split('$').first]
     solr_doc['based_near_linked_sim'] = [val.solrize.last.is_a?(String) ? val.solrize.last : val.solrize.last[:label].split('$').first]
+  end
+
+  def solr_funding_body_linked_insert(solr_doc, val)
+    solr_doc['funding_body_linked_tesim'] = [val.solrize.last.is_a?(String) ? val.solrize.last : val.solrize.last[:label].split('$').first]
+    solr_doc['funding_body_linked_ssim'] = [val.solrize.last.is_a?(String) ? val.solrize.last : val.solrize.last[:label].split('$').first]
+    solr_doc['funding_body_linked_sim'] = [val.solrize.last.is_a?(String) ? val.solrize.last : val.solrize.last[:label].split('$').first]
   end
 
   def default_accept_header

--- a/app/workers/fetch_failed_graph_worker.rb
+++ b/app/workers/fetch_failed_graph_worker.rb
@@ -5,6 +5,7 @@ class FetchFailedGraphWorker
   include Sidekiq::Worker
   sidekiq_options retry: 11
 
+  # rubocop:disable Metrics/MethodLength
   def perform(pid, val, controlled_prop)
     work = ActiveFedora::Base.find(pid)
     solr_doc = work.to_solr
@@ -23,6 +24,7 @@ class FetchFailedGraphWorker
     ActiveFedora::SolrService.add(solr_doc)
     ActiveFedora::SolrService.commit
   end
+  # rubocop:enable Metrics/MethodLength
 
   def solr_based_near_linked_insert(solr_doc, val)
     solr_doc['based_near_linked_tesim'] = [val.solrize.last.is_a?(String) ? val.solrize.last : val.solrize.last[:label].split('$').first]

--- a/app/workers/fetch_graph_worker.rb
+++ b/app/workers/fetch_graph_worker.rb
@@ -10,42 +10,55 @@ class FetchGraphWorker
     work = ActiveFedora::Base.find(pid)
     solr_doc = work.to_solr
 
-    # VARIABLES: Create two labels to store value of location in
-    labels_linked = []
-    labels_only = []
+    # LOOP: Loop through controlled_properties to fetch work
+    work.controlled_properties.each do |cv|
+      # VARIABLES: Create two labels to store value of location in
+      labels_linked = []
+      labels_only = []
 
-    work.attributes['based_near'].each do |val|
-      val = Hyrax::ControlledVocabularies::Location.new(val) if val.include? 'sws.geonames.org'
+      work.attributes[cv.to_s].each do |val|
+        if cv.to_s == 'based_near'
+          val = Hyrax::ControlledVocabularies::Location.new(val) if val.include? 'sws.geonames.org'
+        else
+          val = ScholarsArchive::ControlledVocabularies::ResearchOrganizationRegistry.new(val) if val.include? 'ror.org'
+        end
 
-      next if fetch_and_persist(val, pid) == false
+        next if fetch_and_persist(val, pid, cv) == false
 
-      # ADD: Add the val into the labels arr to be added to solr
-      labels_linked << extracted_label(val.solrize, onlylabel: false)
-      labels_only << extracted_label(val.solrize, onlylabel: true)
+        # ADD: Add the val into the labels arr to be added to solr
+        labels_linked << extracted_label(val.solrize, onlylabel: false)
+        labels_only << extracted_label(val.solrize, onlylabel: true)
+      end
+
+      # INSERT: Added to solr to appropriate field
+      if cv.to_s == 'based_near'
+        solr_based_near_linked_insert(solr_doc, labels_linked)
+        solr_based_near_label_insert(solr_doc, labels_only)
+      else
+        solr_funding_body_linked_insert(solr_doc, labels_linked)
+        solr_funding_body_label_insert(solr_doc, labels_only)
+      end
     end
-
-    # INSERT: Added to solr to appropriate field
-    solr_based_near_linked_insert(solr_doc, labels_linked)
-    solr_based_near_label_insert(solr_doc, labels_only)
 
     ActiveFedora::SolrService.add(solr_doc)
     ActiveFedora::SolrService.commit
   end
   # rubocop:enable Metrics/MethodLength
 
-  def fetch_and_persist(val, pid)
+  def fetch_and_persist(val, pid, controlled_prop)
     begin
       val.fetch(headers: { 'Accept' => default_accept_header }) if val.respond_to?(:fetch)
     # rubocop:disable Style/RescueStandardError
     rescue => e
       Rails.logger.info "Failed #{e}"
-      fetch_failed_graph(pid, val, :based_near)
+      fetch_failed_graph(pid, val, controlled_prop)
       return false
     end
     # rubocop:enable Style/RescueStandardError
     val.persist!
   end
 
+  # SOLR: Add based_near index
   def solr_based_near_linked_insert(solr_doc, labels_linked)
     solr_doc['based_near_linked_tesim'] = labels_linked
     solr_doc['based_near_linked_ssim'] = labels_linked
@@ -55,6 +68,18 @@ class FetchGraphWorker
   def solr_based_near_label_insert(solr_doc, labels_only)
     solr_doc['based_near_label_tesim'] = ScholarsArchive::LabelParserService.location_parse_labels(labels_only)
     solr_doc['based_near_label_sim'] = ScholarsArchive::LabelParserService.location_parse_labels(labels_only)
+  end
+
+  # SOLR: Add funding_body index
+  def solr_funding_body_linked_insert(solr_doc, labels_linked)
+    solr_doc['funding_body_linked_tesim'] = labels_linked
+    solr_doc['funding_body_linked_ssim'] = labels_linked
+    solr_doc['funding_body_linked_sim'] = labels_linked
+  end
+
+  def solr_funding_body_label_insert(solr_doc, labels_only)
+    solr_doc['funding_body_label_tesim'] = labels_only
+    solr_doc['funding_body_label_sim'] = labels_only
   end
 
   def extracted_label(input, onlylabel: false)

--- a/app/workers/fetch_graph_worker.rb
+++ b/app/workers/fetch_graph_worker.rb
@@ -6,6 +6,8 @@ class FetchGraphWorker
   sidekiq_options retry: 11
 
   # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def perform(pid, _user_key)
     work = ActiveFedora::Base.find(pid)
     solr_doc = work.to_solr
@@ -19,8 +21,8 @@ class FetchGraphWorker
       work.attributes[cv.to_s].each do |val|
         if cv.to_s == 'based_near'
           val = Hyrax::ControlledVocabularies::Location.new(val) if val.include? 'sws.geonames.org'
-        else
-          val = ScholarsArchive::ControlledVocabularies::ResearchOrganizationRegistry.new(val) if val.include? 'ror.org'
+        elsif val.include? 'ror.org'
+          val = ScholarsArchive::ControlledVocabularies::ResearchOrganizationRegistry.new(val)
         end
 
         next if fetch_and_persist(val, pid, cv) == false
@@ -44,6 +46,8 @@ class FetchGraphWorker
     ActiveFedora::SolrService.commit
   end
   # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def fetch_and_persist(val, pid, controlled_prop)
     begin

--- a/lib/qa/authorities/geonames.rb
+++ b/lib/qa/authorities/geonames.rb
@@ -49,12 +49,12 @@ module Qa::Authorities
 
     # BUILD: Create a search using id number instead
     def build_id_url(q)
-      query = URI.escape(untaint(q))
+      query = CGI.escape(untaint(q))
       "http://api.geonames.org/getJSON?geonameId=#{query}&username=#{username}"
     end
 
     def build_query_url(q)
-      query = URI.escape(untaint(q))
+      query = CGI.escape(untaint(q))
       "http://api.geonames.org/searchJSON?q=#{query}&username=#{username}&maxRows=10"
     end
 

--- a/lib/qa/authorities/research_organization_registry.rb
+++ b/lib/qa/authorities/research_organization_registry.rb
@@ -18,9 +18,9 @@ module Qa::Authorities
     def search(query)
       # CONDITION: Check if user search by 'id' or 'word'
       if query[0] == '0' && query.length == 9
-        parse_authority_response_with_id(json(build_id_url(URI.escape(untaint(query)))))
+        parse_authority_response_with_id(json(build_id_url(CGI.escape(untaint(query)))))
       else
-        parse_authority_response(json(build_query_url(URI.escape(untaint(query)))))
+        parse_authority_response(json(build_query_url(CGI.escape(untaint(query)))))
       end
     end
 

--- a/lib/qa/authorities/research_organization_registry.rb
+++ b/lib/qa/authorities/research_organization_registry.rb
@@ -18,9 +18,9 @@ module Qa::Authorities
     def search(query)
       # CONDITION: Check if user search by 'id' or 'word'
       if query[0] == '0' && query.length == 9
-        parse_authority_response_with_id(json(build_id_url(query)))
+        parse_authority_response_with_id(json(build_id_url(URI.escape(untaint(query)))))
       else
-        parse_authority_response(json(build_query_url(query)))
+        parse_authority_response(json(build_query_url(URI.escape(untaint(query)))))
       end
     end
 
@@ -31,14 +31,12 @@ module Qa::Authorities
 
     # METHOD: Build search using 'word'
     def build_query_url(query)
-      query_str = URI.escape(untaint(query))
-      "https://api.ror.org/v2/organizations?query=#{query_str}"
+      "https://api.ror.org/v2/organizations?query=#{query}"
     end
 
     # METHOD: Create a search using id number instead
     def build_id_url(query)
-      query_str = URI.escape(untaint(query))
-      "https://api.ror.org/v2/organizations/#{query_str}"
+      "https://api.ror.org/v2/organizations/#{query}"
     end
 
     # METHOD: Find id for full label

--- a/lib/qa/authorities/research_organization_registry.rb
+++ b/lib/qa/authorities/research_organization_registry.rb
@@ -41,6 +41,15 @@ module Qa::Authorities
       "https://api.ror.org/v2/organizations/#{query_str}"
     end
 
+    # METHOD: Find id for full label
+    def find(id)
+      json(find_url(id))
+    end
+
+    def find_url(id)
+      "https://api.ror.org/v2/organizations/#{id}"
+    end
+
     private
 
     # PARSE: Reformats the data received from the service

--- a/lib/scholars_archive/attributes_list.rb
+++ b/lib/scholars_archive/attributes_list.rb
@@ -63,7 +63,7 @@ module ScholarsArchive
         { field: :replaces, render_as: :external_link },
         { field: :nested_ordered_additional_information_label, label: 'Additional Information' },
         { field: :based_near_linked_label, render_as: :search_and_external_link, label: 'Location', search_field: 'based_near_label' },
-        { field: :funding_body, render_as: :faceted, label: I18n.t('simple_form.labels.defaults.funding_body') },
+        { field: :funding_body_label, render_as: :search_and_external_link, label: I18n.t('simple_form.labels.defaults.funding_body'), search_field: 'funding_body_label' },
         { field: :embargo_reason },
         { field: :embargo_date_range },
         { field: :duration, label: I18n.t('simple_form.labels.defaults.duration') },

--- a/lib/scholars_archive/controlled_vocabularies/research_organization_registry.rb
+++ b/lib/scholars_archive/controlled_vocabularies/research_organization_registry.rb
@@ -28,6 +28,11 @@ module ScholarsArchive
         node? ? [] : [rdf_subject.to_s]
       end
 
+      # METHOD: Add in full label fetch for the edit work page
+      def full_label
+        ScholarsArchive::ResearchOrganizationRegistryService.new.full_label(rdf_subject.to_s)
+      end
+
       # METHOD: Override fetch to do a manual fetch on ROR
       def fetch(*_args, &_block)
         persistence_strategy.graph = fetch_graph_manual

--- a/lib/scholars_archive/controlled_vocabularies/research_organization_registry.rb
+++ b/lib/scholars_archive/controlled_vocabularies/research_organization_registry.rb
@@ -55,6 +55,7 @@ module ScholarsArchive
 
       # METHOD: Add in a manual fetch for graph
       def fetch_graph_manual
+        # BUILD: Build the URL to fetch JSON data from it
         url = URI::HTTP.build(host: 'api.ror.org', path: "/v2/organizations/#{rdf_subject.to_s.split('/').last}")
 
         # GET: Get the value for RDF::Literal

--- a/lib/scholars_archive/controlled_vocabularies/research_organization_registry.rb
+++ b/lib/scholars_archive/controlled_vocabularies/research_organization_registry.rb
@@ -73,7 +73,7 @@ module ScholarsArchive
 
         # INGEST: Add in "subject", "predicate", and "object" keys
         subject = RDF::URI(rdf_subject.to_s)
-        predicate = RDF::URI("#{rdf_subject}/item/test")
+        predicate = ::RDF::Vocab::MARCRelators.fnd
         object = RDF::Literal.new(val_literal.join)
 
         # INSERT: Insert the RDF triple into the graph & return graph

--- a/lib/scholars_archive/controlled_vocabularies/research_organization_registry.rb
+++ b/lib/scholars_archive/controlled_vocabularies/research_organization_registry.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module ScholarsArchive
+  module ControlledVocabularies
+    # CLASS: Research Organization Registry (Controlled Vocab)
+    class ResearchOrganizationRegistry < ActiveTriples::Resource
+      include Hyrax::ControlledVocabularies::ResourceLabelCaching
+
+      # METHOD: Setup custom rdf_label
+      def rdf_label
+        labels = Array.wrap(self.class.rdf_label)
+        labels += default_labels
+        # OVERRIDE: From rdf_triples to select only and all english labels
+        values = []
+        labels.each do |label|
+          values += get_values(label).to_a
+        end
+        eng_values = values.select { |val| val.language.in? %i[en en-us] if val.is_a?(RDF::Literal) }
+
+        # We want English first
+        return eng_values unless eng_values.blank?
+
+        # But we'll take non-english if that's all there is
+        return values unless values.blank?
+
+        node? ? [] : [rdf_subject.to_s]
+      end
+
+      # METHOD: To solrize and return a tuple of url & label
+      def solrize
+        return [rdf_subject.to_s] if rdf_label.first.to_s.blank? || rdf_label_uri_same?
+
+        [rdf_subject.to_s, { label: "#{rdf_label}$#{rdf_subject}" }]
+      end
+
+      private
+
+      # METHOD: Double check if rdf_label & subject are the same
+      def rdf_label_uri_same?
+        rdf_label.first.to_s == rdf_subject.to_s
+      end
+    end
+  end
+end

--- a/spec/fixtures/ror.json
+++ b/spec/fixtures/ror.json
@@ -1,0 +1,68 @@
+{
+  "admin": {
+    "created": {
+      "date": "2018-11-14",
+      "schema_version": "1.0"
+    },
+    "last_modified": {
+      "date": "2024-05-13",
+      "schema_version": "2.0"
+    }
+  },
+  "domains": [],
+  "established": 1990,
+  "external_ids": [
+    {
+      "all": [
+        "grid.440350.6"
+      ],
+      "preferred": "grid.440350.6",
+      "type": "grid"
+      },
+      {
+      "all": [
+        "Q30293535"
+      ],
+      "preferred": null,
+      "type": "wikidata"
+    }
+  ],
+  "id": "https://ror.org/01mdg2p21",
+  "links": [
+    {
+      "type": "website",
+      "value": "https://snco.org/learn-explore/at-the-oregon-observatory/"
+    },
+    {
+      "type": "wikipedia",
+      "value": "https://en.wikipedia.org/wiki/Oregon_Observatory"
+    }
+  ],
+  "locations": [
+    {
+      "geonames_details": {
+        "country_code": "US",
+        "country_name": "United States",
+        "lat": 43.886172,
+        "lng": -121.448158,
+        "name": "Sunriver"
+      },
+      "geonames_id": 5755337
+    }
+  ],
+  "names": [
+    {
+      "lang": "en",
+      "types": [
+        "ror_display",
+        "label"
+      ],
+      "value": "Oregon Observatory"
+    }
+  ],
+  "relationships": [],
+  "status": "active",
+  "types": [
+    "facility"
+  ]
+}

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe SolrDocument do
     end
   end
 
+  # TEST: New test on funding_body_label
+  describe '#funding_body_label' do
+    context 'when an funding_body_label is indexed' do
+      document = described_class.new({
+                                       'funding_body_linked_ssim' => ['label1$www.blah.com']
+                                     })
+      it 'should return the label' do
+        expect(document.funding_body_label).to eq [{ 'label' => 'label1', 'uri' => 'www.blah.com' }]
+      end
+    end
+  end
+
   describe '#embargo_date_range' do
     context 'when an embargo_date_range is indexed' do
       document = described_class.new({

--- a/spec/services/scholars_archive/research_organization_registry_service_spec.rb
+++ b/spec/services/scholars_archive/research_organization_registry_service_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe ScholarsArchive::ResearchOrganizationRegistryService do
+  let(:service) { described_class.new }
+
+  # STUB: Add in a fetch for request on URI fetch
+  before do
+    stub_request(:get, 'https://api.ror.org/v2/organizations/')
+      .with(query: hash_including({ 'id': 'https://ror.org/01mdg2p21' }))
+      .to_return(status: 200, body: File.open(File.join(fixture_path, 'ror.json')))
+  end
+
+  # TEST: Do test on w/ uri string, obj, non-valid, and nil
+  context 'with ROR uri string' do
+    let(:uri) { 'https://ror.org/01mdg2p21' }
+
+    describe 'full_label' do
+      it 'returns a full label' do
+        allow(service).to receive(:full_label).with(uri).and_return('Oregon Observatory')
+        expect(service.full_label(uri)).to eq 'Oregon Observatory'
+      end
+    end
+  end
+
+  context 'with ROR uri object' do
+    let(:uri) { URI('https://ror.org/01mdg2p21') }
+
+    describe 'full_label' do
+      it 'returns a full label' do
+        allow(service).to receive(:full_label).with(uri).and_return('Oregon Observatory')
+        expect(service.full_label(uri)).to eq 'Oregon Observatory'
+      end
+    end
+  end
+
+  context 'with invalid type' do
+    let(:uri) { 5_037_649 }
+
+    describe 'full_label' do
+      it 'returns a full label' do
+        expect { service.full_label(uri) }.to raise_error
+      end
+    end
+  end
+
+  context 'with blank object' do
+    let(:uri) { nil }
+
+    describe 'full_label' do
+      it 'returns a full label' do
+        expect(service.full_label(uri)).to eq nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
`FEATURE:` Add in an autocomplete search function to the new `ROR` search based into the `funding_body`.

`PROGRESS:`
`Part 1: Display`
- [x] Add in the new `funding_body` view
- [x] Update the JS script for `autocomplete` w/ `funding_body`
- [x] Create a new `QA` search for ROR

`Part 2: CV`
- [x] Create the control vocab for `ROR`
- [x] Update the `fetch` method to make the `RDF::Graph & RDF::Statement` 
- [x] Be able to save onto `curation_concern`
- [x] Index the value
- [x] Display in work `edit` page

`Part 3: Test`
- [x] Make sure it holds value
- [x] Make sure it display on show page
- [x] Make sure it display in search on SA
- [x] Make sure the facet is not an URI but with `label`
- [x] Create `spec` if needed