### PR TITLE
Remove an extra field in funding body

### DIFF
--- a/app/assets/javascripts/hyrax/autocomplete.es6
+++ b/app/assets/javascripts/hyrax/autocomplete.es6
@@ -54,8 +54,11 @@ export default class Autocomplete {
         break
       // ADD: Add case for 'funding_body' on autocomplete
       case 'funding_body':
+        new LinkedData(element, url)
+        break
       case 'based_near':
         new LinkedData(element, url)
+        break
       default:
         new Default(element, url)
         break

--- a/app/forms/concerns/scholars_archive/article_terms.rb
+++ b/app/forms/concerns/scholars_archive/article_terms.rb
@@ -18,6 +18,7 @@ module ScholarsArchive
          doi
          academic_affiliation
          other_affiliation
+         funding_body
          funding_statement
          license
          rights_statement
@@ -38,7 +39,6 @@ module ScholarsArchive
     # rubocop:disable Metrics/MethodLength
     def self.secondary_terms
       %i[in_series
-         funding_body
          conference_name
          conference_section
          conference_location

--- a/app/models/concerns/scholars_archive/finalize_nested_metadata.rb
+++ b/app/models/concerns/scholars_archive/finalize_nested_metadata.rb
@@ -11,6 +11,7 @@ module ScholarsArchive
 
     included do
       accepts_nested_attributes_for :based_near, allow_destroy: true, reject_if: proc { |a| a[:id].blank? }
+      accepts_nested_attributes_for :funding_body, allow_destroy: true, reject_if: proc { |a| a[:id].blank? }
       accepts_nested_attributes_for :nested_geo, allow_destroy: true, reject_if: :all_blank
       accepts_nested_attributes_for :nested_related_items, allow_destroy: true, reject_if: :all_blank
       # reject if all attributes all blank OR if either index or creator is blank

--- a/app/views/records/edit_fields/_funding_body.html.erb
+++ b/app/views/records/edit_fields/_funding_body.html.erb
@@ -1,4 +1,6 @@
 <%# OVERRIDE: Override the edit field for 'funding_body' to have autocomplete field %>
+<%# ADD: Filter out an extra field on :new or if the area is blank %>
+<% f.object.funding_body.delete_at(1) if f.object.funding_body.count == 2 %>
 <%= f.input key,
             as: :controlled_vocabulary,
             placeholder: 'Search for a funding body',


### PR DESCRIPTION
`BUG:` Add in a way to remove an extra field on `:new` or `work have blank` funding body for work on depositor form.