### PR TITLE
Add space to override bootstrap variables

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,0 +1,2 @@
+// Bootstrap settings
+$secondary: #fff;

--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -4,6 +4,7 @@
  *= require_self
 */
 
+@import "_variables";
 @import 'bootstrap';
 @import "browse_everything/browse_everything_bootstrap4";
 @import 'blacklight/blacklight';

--- a/app/assets/stylesheets/osu.scss
+++ b/app/assets/stylesheets/osu.scss
@@ -646,6 +646,7 @@ button.copy-single-use-link {
 // Added so Bootstrap buttons in Mac Chrome don't have a white fill color
 button.btn-secondary {
   -webkit-appearance: none!important;
+  border-color: #ccc
 }
 
 .public-collapse > p {


### PR DESCRIPTION
You can override bootstrap variables in `_variables.scss` for global bootstrap changes
https://github.com/twbs/bootstrap-rubygem/blob/4.6-stable/assets/stylesheets/bootstrap/_variables.scss