### PR TITLE
Remove DOI on approve deposit

### DIFF
--- a/app/services/scholars_archive/workflow/deposited_notification.rb
+++ b/app/services/scholars_archive/workflow/deposited_notification.rb
@@ -16,7 +16,7 @@ module ScholarsArchive
       end
 
       def message
-        "Your deposit: #{title} DOI:#{@doi} (#{link_to work_id, citeable_url}) was approved by #{user.user_key} and is now live in ScholarsArchive@OSU. #{comment} \n\n Citeable URL: #{citeable_url}"
+        "Your deposit: '#{title}' was approved by #{user.user_key} and is now live in ScholarsArchive@OSU. #{comment} \n\n Citeable URL: #{citeable_url}"
       end
 
       def users_to_notify


### PR DESCRIPTION
`UPDATE:` Remove the `DOI` in the approval message when accept a work.