### PR TITLE
Add in 'none' to Accessibility Feature

### DIFF
--- a/config/authorities/accessibility_feature.yml
+++ b/config/authorities/accessibility_feature.yml
@@ -86,6 +86,9 @@ terms:
 - id: "tactileObject"
   term: "tactileObject"
   active: true
+- id: "none"
+  term: "none"
+  active: true
 - id: "unknown"
   term: "unknown"
   active: true


### PR DESCRIPTION
`FEATURE:` Update the `accessibility_feature` to include in the value of `none` from previous work done on `accessibility_feature`.

fixes #2761 