### PR TITLE
add branch name to the image tag and deployed version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,10 +206,11 @@ jobs:
           name: Generate deployed version
           command: |
             export GIT_SHORT_HASH=$(git rev-parse --short HEAD)
+            export GIT_BRANCH=$(git branch --show-current)
             export DATETIME=$(date "+%Y%m%d%H%M%S")
             export YABEDA_PROMETHEUS_PATH=/tmp/prom
-            echo export TAG="$DATETIME-$GIT_SHORT_HASH" >> $BASH_ENV
-            echo export DEPLOYED_VERSION="$DATETIME-$GIT_SHORT_HASH" >> $BASH_ENV
+            echo export TAG="$DATETIME-$GIT_SHORT_HASH-$GIT_BRANCH" >> $BASH_ENV
+            echo export DEPLOYED_VERSION="$DATETIME-$GIT_SHORT_HASH-$GIT_BRANCH" >> $BASH_ENV
             echo export YABEDA_PROMETHEUS_PATH=/tmp/prom >> $BASH_ENV
       - setup_remote_docker:
           version: docker23


### PR DESCRIPTION
adds branch name to image tag name

former: `<datetime>`-`<git commit hash>`
new: `<datetime>`-`<git commit hash>`-`git branch`