### PR TITLE
Combine challenge destination query params with an & instead of a ?

### DIFF
--- a/app/controllers/bot_detection_controller.rb
+++ b/app/controllers/bot_detection_controller.rb
@@ -33,7 +33,7 @@ class BotDetectionController < ApplicationController
 
   def challenge
     @dest = request.query_parameters.delete('dest')
-    @dest += "?#{request.query_parameters.to_query}"
+    @dest += "&#{request.query_parameters.to_query}"
     @dest = CGI.unescape(@dest)
   end
 


### PR DESCRIPTION
Same fix as OregonDigital/OD2#3420