### PR TITLE
Updates to check persisted

### DIFF
--- a/app/views/hyrax/base/_form_attestation_component.html.erb
+++ b/app/views/hyrax/base/_form_attestation_component.html.erb
@@ -4,7 +4,7 @@
   <ul class="visibility">
     <li class="radio">
       <label>
-        <%= f.radio_button :attest, true %>
+        <%= f.radio_button :attest, true, checked: f.object.persisted? %>
         <b>I attest that my work is accessible.</b>
         <ul>
           <li>


### PR DESCRIPTION
This makes sure that on New form, the attestation isn't chosen.

On Edit, since the user already chose their attestation, they should already be in contact with the person for help, otherwise their work is accessible. So now we default to no help needed.

Do we want to actually persist this data? We could extend functionality further but that would mean adding the data to the object which would be heavy changes. 