### PR TITLE
Implement Oembed URL as part of SA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,7 @@ gem 'libhoney', '>= 2.2.0'
 
 # Oembed content
 gem 'ruby-oembed'
+gem 'blacklight-oembed'
 
 # Yabeda
 gem 'yabeda'

--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,9 @@ gem 'down', '~> 5.0'
 gem 'honeycomb-beeline', '>= 2.10.0'
 gem 'libhoney', '>= 2.2.0'
 
+# Oembed content
+gem 'ruby-oembed'
+
 # Yabeda
 gem 'yabeda'
 gem 'yabeda-prometheus'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,11 @@ GEM
       bootstrap-sass (~> 3.0)
       openseadragon (>= 0.2.0)
       rails
+    blacklight-oembed (0.3.0)
+      blacklight (>= 5.0, < 7)
+      bootstrap-sass (~> 3.0)
+      rails
+      ruby-oembed
     blacklight_advanced_search (6.4.1)
       blacklight (~> 6.0, >= 6.0.1)
       parslet
@@ -1146,6 +1151,7 @@ PLATFORMS
 DEPENDENCIES
   addressable (= 2.8.0)
   bagit (~> 0.6)
+  blacklight-oembed
   blacklight_advanced_search
   blacklight_oai_provider
   blacklight_range_limit

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -944,6 +944,7 @@ GEM
     ruby-debug-ide (0.7.3)
       rake (>= 0.8.1)
     ruby-next-core (1.0.3)
+    ruby-oembed (0.18.1)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (1.3.0)
@@ -1197,6 +1198,7 @@ DEPENDENCIES
   rubocop (>= 1.50.2)
   rubocop-rspec (>= 2.20.0)
   ruby-debug-ide
+  ruby-oembed
   rubycas-client!
   rubycas-client-rails!
   rubyzip (~> 1.3.0)

--- a/app/actors/scholars_archive/actors/create_with_oembed_url_actor.rb
+++ b/app/actors/scholars_archive/actors/create_with_oembed_url_actor.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'oembed'
-
 module ScholarsArchive
   module Actors
     # If there is a key `:oembed_urls' in the attributes, it extracts the URLs, creates a fileset, addes the URL as metadata, and attaches a dummy image

--- a/app/actors/scholars_archive/actors/create_with_oembed_url_actor.rb
+++ b/app/actors/scholars_archive/actors/create_with_oembed_url_actor.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'oembed'
+
+module ScholarsArchive
+  module Actors
+    # If there is a key `:oembed_urls' in the attributes, it extracts the URLs, creates a fileset, addes the URL as metadata, and attaches a dummy image
+    # to the work.
+    class CreateWithOembedUrlActor < Hyrax::Actors::AbstractActor
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if create was successful
+      def create(env)
+        oembed_url = env.attributes.delete(:oembed_url)
+        next_actor.create(env) && attach_files(env, oembed_url)
+      end
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if update was successful
+      def update(env)
+        oembed_url = env.attributes.delete(:oembed_url)
+        next_actor.update(env) && attach_files(env, oembed_url)
+      end
+
+      private
+
+      # @param [HashWithIndifferentAccess] oembed_urls
+      # @return [TrueClass]
+      def attach_files(env, oembed_url)
+        return true unless oembed_url
+
+        oembed_url.each do |url|
+          next if url.blank?
+
+          # Escape any space characters, so that this is a legal URI
+          uri = URI.parse(Addressable::URI.escape(url.strip))
+          create_file_from_url(env, uri)
+        end
+
+        true
+      end
+
+      # Utility for creating FileSet from an oEmbed URL
+      # Used to create a FileSet with a dummy image and store the url into a metadata field
+      # rubocop:disable Metrics/MethodLength
+      def create_file_from_url(env, uri)
+        oembed_url = URI.decode_www_form_component(uri.to_s)
+        use_valkyrie = false
+        fs_class = env.curation_concern.is_a?(Valkyrie::Resource) ? Hyrax::FileSet : ::FileSet
+
+        file_set = fs_class.new(oembed_url: oembed_url) do |fs|
+          title = 'oEmbed Media'
+          begin
+            resource = ::OEmbed::Providers.get(oembed_url)
+            title = resource.respond_to?(:title) ? resource.title : "oEmbed Media from #{resource.provider_name}"
+          rescue ::OEmbed::Error => e
+            msg = e.message
+            msg += ' (broken or non-allowlisted URI)' if e.is_a? OEmbed::NotFound
+            OembedError.find_or_create_by(document_id: fs.id) do |error|
+              error.document_id = fs.id
+            end.add_error(msg)
+          end
+          fs.title = Array(title)
+        end
+
+        if env.curation_concern.is_a? Valkyrie::Resource
+          file_set = Hyrax.persister.save(resource: file_set)
+          use_valkyrie = true
+        end
+
+        actor = Hyrax::Actors::FileSetActor.new(file_set, env.user, use_valkyrie: use_valkyrie)
+        actor.create_metadata(visibility: env.curation_concern.visibility)
+        actor.attach_to_work(env.curation_concern)
+        file_set.save! if file_set.respond_to?(:save!)
+      end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
+    end
+  end
+end

--- a/app/assets/javascripts/blacklight_oembed.js
+++ b/app/assets/javascripts/blacklight_oembed.js
@@ -1,0 +1,5 @@
+//= require 'blacklight_oembed/jquery.oembed.js'
+
+Blacklight.onLoad(function() {
+  $('[data-embed-url]').oEmbed();
+});

--- a/app/assets/javascripts/hyrax/save_work/uploaded_files.es6
+++ b/app/assets/javascripts/hyrax/save_work/uploaded_files.es6
@@ -7,6 +7,7 @@ export class UploadedFiles {
     this.element.bind('fileuploadcompleted', callback)
     this.element.bind('fileuploaddestroyed', callback)
     $('#ext_relation').bind('blur', callback)
+    $('#oembed_url').bind('blur', callback)
   }
 
   get hasFileRequirement() {
@@ -22,8 +23,9 @@ export class UploadedFiles {
   get hasFiles() {
     let fileField = this.form.find('input[name="uploaded_files[]"]')
     let extField = this.form.find('input[name="ext_relation[]"]:valid')
+    let oembedField = this.form.find('input[name="oembed_url[]"]:valid')
     
-    return (fileField.length > 0 && !extField.val()) || (extField.val() && fileField.length < 1)
+    return ((fileField.length > 0 || oembedField.val()) && !extField.val()) || (extField.val() && (fileField.length < 1 || !oembedField.val()))
   }
 
   get hasNewFiles() {

--- a/app/assets/javascripts/scholars_archive/save_work/uploaded_files_check.js
+++ b/app/assets/javascripts/scholars_archive/save_work/uploaded_files_check.js
@@ -9,9 +9,10 @@ $(document).ready(function() {
     // GET: Select the value from the work
     var fileField = $('input[name="uploaded_files[]"]');
     var extFieldNew = $('input[name="ext_relation[]"]:valid');
+    var oembedFieldNew = $('input[name="oembed_url[]"]:valid');
     
     // CHECK: Check to see if the file length or text value is both fill out
-    if (fileField.length > 0 && extFieldNew.val().length > 0) {
+    if ((fileField.length > 0 || oembedFieldNew.val().length > 0) && extFieldNew.val().length > 0) {
       alert('ERROR! Please only submit one of the following, either only a file upload or an URL link');
       return false;
     } else if ((extFieldCurr.text().length != 0) && (extFieldNew.val().length == 0)) {

--- a/app/assets/stylesheets/osu.scss
+++ b/app/assets/stylesheets/osu.scss
@@ -752,3 +752,10 @@ button.btn-secondary {
   margin-top: 0;
   top: auto !important;
 }
+
+// ADD: Create a custom size to fit around with oEmbed content
+.oembed-widget-preview iframe,
+.oembed-widget-preview .oembed iframe {
+  width: 250px !important;
+  height: 150px !important;
+}

--- a/app/controllers/blacklight/oembed/embed_controller.rb
+++ b/app/controllers/blacklight/oembed/embed_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Blacklight::Oembed
+  # Override blacklight-oembed gem controller. We're only interested in
+  # get_embed_content, but keep the changes compatible incase we can use
+  # Blacklight later
+  class EmbedController < ActionController::Base
+    def show
+      render json: { html: get_embed_content(params[:url], additional_params) }
+    end
+
+    private
+
+    # rubocop:disable Metrics/MethodLength
+    def get_embed_content(url, add_params)
+      # Retrieve embeddable content from cache, or store if not found
+      Rails.cache.fetch("oembed/embed/#{url}", expires_in: 12.hours) do
+        OEmbed::Providers.get(url, **add_params).html.html_safe
+      end
+    rescue OEmbed::Error => e
+      msg = e.message
+      msg += ' (broken or non-allowlisted URI)' if e.is_a? ::OEmbed::NotFound
+      # Create OembedError for oEmbed Errors dashboard
+
+      Hyrax.query_service
+           .find_all_of_model(model: Hyrax::FileSet)
+           .select { |file_set| file_set.oembed_url == url }
+           .each do |file_set|
+        OembedError.find_or_create_by(document_id: file_set.id.to_s) do |error|
+          error.document_id = file_set.id
+        end.add_error(msg)
+      end
+
+      "<dt>oEmbed encountered an error</dt><dd>#{msg}</dd>".html_safe
+    end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
+
+    ##
+    # Allows for blacklight-oembed users to pass through additional configured
+    # parameters
+    def additional_params
+      params
+        .slice(*Blacklight::Oembed::Engine.config.additional_params)
+        .to_unsafe_h
+        .symbolize_keys
+    end
+  end
+end

--- a/app/controllers/concerns/scholars_archive/works_controller_behavior.rb
+++ b/app/controllers/concerns/scholars_archive/works_controller_behavior.rb
@@ -57,8 +57,12 @@ module ScholarsArchive
     # We can use Hyrax::WorksControllerBehavior definition and add on additional params we want
     def attributes_for_actor
       attributes = super
+
       ext_relation = params.fetch(:ext_relation, [])
       attributes[:ext_relation] = ext_relation
+
+      oembed_url = params.fetch(:oembed_url, [])
+      attributes[:oembed_url] = oembed_url
 
       attributes
     end

--- a/app/helpers/hyrax/file_set_helper.rb
+++ b/app/helpers/hyrax/file_set_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# OVERRIDE: Add in this file to create a custom path to display icon for external resource
+# OVERRIDE: Add in this file to create a custom path to display icon for external resource & oembed
 module Hyrax::FileSetHelper
   ##
   # @todo inline the "workflow restriction" into the `can?(:download)` check.
@@ -40,11 +40,15 @@ module Hyrax::FileSetHelper
 
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Style/StringConcatenation
-  # MODIFY: Add in the 'ext_relation' keyword to the display
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
+  # MODIFY: Add in the 'ext_relation' & 'oembed_url' keyword to the display
   def media_display_partial(file_set)
     'hyrax/file_sets/media_display/' +
       if !file_set.ext_relation.blank?
         'ext_relation'
+      elsif !file_set.oembed_url.blank?
+        'oembed_url'
       elsif file_set.image?
         'image'
       elsif file_set.video?
@@ -61,4 +65,6 @@ module Hyrax::FileSetHelper
   end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Style/StringConcatenation
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
 end

--- a/app/indexers/scholars_archive/file_set_indexer.rb
+++ b/app/indexers/scholars_archive/file_set_indexer.rb
@@ -10,6 +10,11 @@ module ScholarsArchive
         solr_doc['ext_relation_sim'] = object.ext_relation
         solr_doc['ext_relation_ssim'] = object.ext_relation
         solr_doc['ext_relation_tesim'] = object.ext_relation
+
+        # ADD: Solrize the :oembed_url
+        solr_doc['oembed_url_sim'] = object.oembed_url
+        solr_doc['oembed_url_ssim'] = object.oembed_url
+        solr_doc['oembed_url_tesim'] = object.oembed_url
       end
     end
   end

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -5,6 +5,9 @@ class FileSet < ActiveFedora::Base
   # PREDICATE: Add in :ext_relation for external resource
   property :ext_relation, predicate: ::RDF::URI.new('http://rioxx.net/schema/v3.0/rioxxterms/#ext_relation'), multiple: false
 
+  # PREDICATE: Add in :oembed_url for oembed
+  property :oembed_url, predicate: ::RDF::URI.new('http://opaquenamespace.org/ns/oembed'), multiple: false
+
   include ::ScholarsArchive::DefaultMetadata
   include ::Hyrax::FileSetBehavior
   include ::ScholarsArchive::FinalizeNestedMetadata
@@ -15,6 +18,11 @@ class FileSet < ActiveFedora::Base
   # METHOD: To check true/false if exist for external resource
   def ext_relation?
     !ext_relation.blank?
+  end
+
+  # METHOD: To check true/false if exist for oembed
+  def oembed?
+    !oembed_url.blank?
   end
 
   private

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -27,5 +27,11 @@ class FileSet < ActiveFedora::Base
 
   private
 
+  # METHOD: If the oembed_url changed all previous errors are invalid
+  def resolve_oembed_errors
+    errors = OembedError.find_by(document_id: id)
+    errors.delete if oembed_url_changed? && !errors.blank?
+  end
+
   def set_defaults; end
 end

--- a/app/models/oembed_error.rb
+++ b/app/models/oembed_error.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal:true
+
+# String errors related to oEmbed links
+class OembedError < ApplicationRecord
+  serialize :oembed_errors, Array
+
+  validates_presence_of :document_id
+
+  # Make errors a unique array
+  before_save :unique_errors
+  after_save :alert_depositor
+
+  # Make sure oembed_errors initializes as an array
+  def initialize(document_id, oembed_error = nil)
+    super()
+    @document_id ||= document_id
+    @oembed_errors ||= [oembed_error]
+  end
+
+  def add_error(error)
+    oembed_errors << error unless oembed_errors.include? error
+    save
+  end
+
+  private
+
+  # Store errors as a symbol/string and we only want unique errors to avoid
+  # stacking up a bunch of the same error
+  def unique_errors
+    oembed_errors.map!(&:to_s).uniq!
+  end
+
+  def alert_depositor
+    # Only alert user if new errors are added
+    return unless saved_change_to_oembed_errors?
+
+    user = User.find_by_user_key(Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: document_id).depositor)
+    Hyrax.config.callback.run(:after_oembed_error, user, oembed_errors)
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -211,6 +211,7 @@ class SolrDocument
     documentation
     web_of_science_uid
     ext_relation
+    oembed_url
   ]
 
   field_semantics.merge!(

--- a/app/presenters/concerns/scholars_archive/default_presenter_behavior.rb
+++ b/app/presenters/concerns/scholars_archive/default_presenter_behavior.rb
@@ -45,10 +45,31 @@ module ScholarsArchive
       ext_url
     end
 
+    # METHOD: Add in a method to check if oembed_url exist & fetch the value
+    def oembed_url?
+      file_set_presenters.any? do |presenter|
+        oem?(presenter, true)
+      end
+    end
+
+    def oembed_url
+      oem_url = ''
+
+      file_set_presenters.any? do |presenter|
+        oem_url = oem?(presenter, false)
+      end
+
+      oem_url
+    end
+
     private
 
     def ext?(presenter, control_stm)
       control_stm ? !presenter.ext_relation.blank? : presenter.ext_relation
+    end
+
+    def oem?(presenter, control_stm)
+      control_stm ? !presenter.oembed_url.blank? : presenter.oembed_url
     end
   end
 end

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 module Hyrax
+  # rubocop:disable Metrics/ClassLength
   # File Set Presenter
   class FileSetPresenter
     include ModelProxy
@@ -24,19 +25,19 @@ module Hyrax
 
     # CurationConcern methods
     delegate :stringify_keys, :human_readable_type, :collection?, :image?, :video?,
-             :audio?, :pdf?, :office_document?, :representative_id, :ext_relation?, :to_s, to: :solr_document
+             :audio?, :pdf?, :office_document?, :representative_id, :ext_relation?, :oembed_url?, :to_s, to: :solr_document
 
     # Methods used by blacklight helpers
     delegate :has?, :first, :fetch, to: :solr_document
 
     # Metadata Methods
-    # ADD: Put in :ext_relation to the presenter
+    # ADD: Put in :ext_relation & :oembed_url to the presenter
     delegate :title, :label, :description, :creator, :contributor, :subject,
              :publisher, :language, :date_uploaded,
              :embargo_release_date, :lease_expiration_date,
              :depositor, :keyword, :title_or_label, :keyword,
              :date_created, :date_modified, :itemtype,
-             :original_file_id, :ext_relation,
+             :original_file_id, :ext_relation, :oembed_url,
              to: :solr_document
 
     delegate :member_of_collection_ids, to: :parent
@@ -122,11 +123,25 @@ module Hyrax
       ext?(solr_document, false)
     end
 
+    # METHOD: Declare two methods to fetch out the :oembed_url & check if it exist
+    def oembed_url?
+      oem?(solr_document, true)
+    end
+
+    def oembed_url
+      oem?(solr_document, false)
+    end
+
     private
 
     def ext?(solr_document, control_stm)
       curation_concern = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: solr_document.id, use_valkyrie: false)
       control_stm ? !curation_concern.ext_relation.blank? : curation_concern.ext_relation
+    end
+
+    def oem?(solr_document, control_stm)
+      curation_concern = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: solr_document.id, use_valkyrie: false)
+      control_stm ? !curation_concern.oembed_url.blank? : curation_concern.oembed_url
     end
 
     def link_presenter_class
@@ -149,4 +164,5 @@ module Hyrax
     end
     # rubocop:enable Metrics/MethodLength
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/services/scholars_archive/oembed_error_service.rb
+++ b/app/services/scholars_archive/oembed_error_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal:true
+
+module ScholarsArchive
+  # Message and Subject definitions for oEmbed error notifications in Hyrax
+  # messaging service
+  class OembedErrorService < Hyrax::AbstractMessageService
+    attr_reader :user, :messages
+    def initialize(user, messages)
+      @user = user
+      @messages = messages.to_sentence
+    end
+
+    def message
+      I18n.t(
+        'hyrax.notifications.oembed_error.message',
+        messages: messages
+      )
+    end
+
+    def subject
+      I18n.t('hyrax.notifications.oembed_error.subject')
+    end
+  end
+end

--- a/app/services/scholars_archive/oembed_error_service.rb
+++ b/app/services/scholars_archive/oembed_error_service.rb
@@ -5,10 +5,13 @@ module ScholarsArchive
   # messaging service
   class OembedErrorService < Hyrax::AbstractMessageService
     attr_reader :user, :messages
+
+    # rubocop:disable Lint/MissingSuper
     def initialize(user, messages)
       @user = user
       @messages = messages.to_sentence
     end
+    # rubocop:enable Lint/MissingSuper
 
     def message
       I18n.t(

--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -62,6 +62,15 @@
         </div>
      </div>
 
+    <%# FIELD: Add field to have a link URL rather file upload using :oembed_url %>
+    <br/><br/>
+
+    <div class="form-group string optional">
+      <label id="oembed_url_label" class="control-label string optional" for="oembed_url"><%= t('simple_form.labels.defaults.oembed_url') %></label>
+      <p class="help-block"><%= t('simple_form.hints.defaults.oembed_url') %></p>
+      <input class="form-control string optional" type="url" value="" name="oembed_url[]" id="oembed_url">
+    </div>
+
     <%# FIELD: Add field to have a link URL rather file upload using :ext_relation %>
     <% @work_lists = ['GraduateThesisOrDissertation', 'HonorsCollegeThesis', 'GraduateProject', 'UndergraduateThesisOrProject'] %>
     <% if !@work_lists.include?(f.object.model.model_name.name) %>

--- a/app/views/hyrax/file_sets/_form.html.erb
+++ b/app/views/hyrax/file_sets/_form.html.erb
@@ -8,6 +8,16 @@
 
     <br/>
 
+    <%# ADD: Create the :oembed_url field to edit on the FileSet %>
+    <% if !curation_concern.oembed_url.blank? %>
+      <span class="control-label">
+        <%= label_tag 'file_set[oembed_url]', t('.oembed_url'),  class: "string optional" %>
+      </span>
+      <%= text_field_tag 'file_set[oembed_url]', curation_concern.oembed_url, class: 'form-control', type: 'url', required: true %>
+    <% end %>
+
+    <br/>
+
     <%# ADD: Create the :ext_relation field to edit on the FileSet %>
     <% if !curation_concern.ext_relation.blank? %>
       <h2><%= t('.edit_url') %></h2>

--- a/app/views/hyrax/file_sets/_show_details.html.erb
+++ b/app/views/hyrax/file_sets/_show_details.html.erb
@@ -1,0 +1,37 @@
+<h2><%= t(".file_details") %></h2>
+<dl class="file-show-term file-show-details">
+  <div class="row">
+    <dt class="col-5"><%= t(".depositor") %></dt>
+    <dd class="col-7" itemprop="accountablePerson" itemscope itemtype="http://schema.org/Person"><span itemprop="name"><%= link_to_profile @presenter.depositor %></span></dd>
+  </div>
+  <div class="row">
+    <dt class="col-5"><%= t(".date_uploaded") %></dt>
+    <dd class="col-7" itemprop="datePublished"><%= @presenter.date_uploaded %></dd>
+  </div>
+  <div class="row">
+    <dt class="col-5"><%= t(".date_modified") %></dt>
+    <dd class="col-7" itemprop="dateModified"><%= @presenter.date_modified %></dd>
+  </div>
+  <div class="row">
+    <dt class="col-5"><%= t(".fixity_check") %></dt>
+    <dd class="col-7"><%= @presenter.fixity_check_status %></dd>
+  </div>
+  <%# OVERRIDE FROM HYRAX to show oembed_url %>
+  <%BREAK%>
+  <% if @presenter.solr_document['oembed_url_tesim'].present? %>
+    <div class="row">
+      <dt class="col-5"><%= t(".oembed_url") %></dt>
+      <dd class="col-7"><%= @presenter.solr_document['oembed_url_tesim'] %></dd>
+    </div>
+  <% end %>
+  <div class="row">
+    <dt class="col-5"><%= t(".characterization") %></dt>
+    <dd class="col-7">
+      <% if @presenter.characterized? %>
+        <%= render 'show_characterization_details' %>
+      <% else %>
+        <%= t(".not_yet_characterized") %>
+      <% end %>
+    </dd>
+  </div>
+</dl>

--- a/app/views/hyrax/file_sets/_show_details.html.erb
+++ b/app/views/hyrax/file_sets/_show_details.html.erb
@@ -17,7 +17,6 @@
     <dd class="col-7"><%= @presenter.fixity_check_status %></dd>
   </div>
   <%# OVERRIDE FROM HYRAX to show oembed_url %>
-  <%BREAK%>
   <% if @presenter.solr_document['oembed_url_tesim'].present? %>
     <div class="row">
       <dt class="col-5"><%= t(".oembed_url") %></dt>

--- a/app/views/hyrax/file_sets/media_display/_oembed_url.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_oembed_url.html.erb
@@ -1,0 +1,10 @@
+<%# VIEW: Add in an iframe view to the embedded video %>
+<div class='oembed-widget-preview'>
+  <%= content_tag(:div, '',
+      data: {
+        embed_url:
+          Blacklight::Oembed::Engine.routes.url_helpers.embed_path(url: Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: @presenter.class.name.include?('FileSetPresenter') ? @presenter.id : @presenter.representative_id, use_valkyrie: false).oembed_url)
+      }
+    )
+  %>
+</div>

--- a/config/initializers/hacks/hyrax_file_set_edit_form.rb
+++ b/config/initializers/hacks/hyrax_file_set_edit_form.rb
@@ -2,7 +2,7 @@
 
 Rails.application.config.to_prepare do
   Hyrax::Forms::FileSetEditForm.class_eval do
-    # Add embargo_reason & ext_relation to permited FileSet terms
-    self.terms += [:embargo_reason, :ext_relation]
+    # Add embargo_reason & ext_relation & oembed_url to permited FileSet terms
+    self.terms += %i[embargo_reason ext_relation oembed_url]
   end
 end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -231,8 +231,16 @@ Hyrax.config do |config|
   # ActiveJob queue to handle ingest-like jobs
   config.ingest_queue_name = :ingest
 
-  # Actor factory add in a custom fileset actor with :ext_relation
-  Hyrax::CurationConcern.actor_factory.insert_before Hyrax::Actors::CreateWithRemoteFilesActor, ScholarsArchive::Actors::CreateWithExtRelationActor
+  # Actor factory add in a custom fileset actor with :ext_relation & :oembed_url
+  Hyrax::CurationConcern.actor_factory.insert_before(
+    Hyrax::Actors::CreateWithRemoteFilesActor,
+    ScholarsArchive::Actors::CreateWithExtRelationActor
+  )
+
+  Hyrax::CurationConcern.actor_factory.insert_before(
+    Hyrax::Actors::CreateWithRemoteFilesActor,
+    ScholarsArchive::Actors::CreateWithOembedUrlActor
+  )
 
   ## Attributes for the lock manager which ensures a single process/thread is mutating a ore:Aggregation at once.
   # How many times to retry to acquire the lock before raising UnableToAcquireLockError

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -286,7 +286,7 @@ end
 
 # Trigger the event for Oembed Error
 Hyrax.config.callback.set(:after_oembed_error) do |user, errors|
-  OregonDigital::OembedErrorService.new(user, errors).call
+  ScholarsArchive::OembedErrorService.new(user, errors).call
 end
 
 Hyrax::Engine.routes.default_url_options = Rails.application.config.action_mailer.default_url_options

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -284,6 +284,11 @@ Hyrax.config.callback.set(:after_fixity_check_failure) do |_file_set, _checksum_
   nil
 end
 
+# Trigger the event for Oembed Error
+Hyrax.config.callback.set(:after_oembed_error) do |user, errors|
+  OregonDigital::OembedErrorService.new(user, errors).call
+end
+
 Hyrax::Engine.routes.default_url_options = Rails.application.config.action_mailer.default_url_options
 Rails.application.routes.default_url_options = Rails.application.config.action_mailer.default_url_options
 

--- a/config/initializers/oembed.rb
+++ b/config/initializers/oembed.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Add in an initializer to get all the oembed content onto the controller
+require 'oembed'
+require 'oembed/providers'
+
+OEmbed::Providers.register_all
+
+## Register OSU Mediaspace Provider
+osu_ms_provider = OEmbed::Provider.new('https://media.oregonstate.edu/oembed')
+osu_ms_provider << 'https://media.oregonstate.edu/id*'
+osu_ms_provider << 'https://media.oregonstate.edu/media/id*'
+osu_ms_provider << 'https://media.oregonstate.edu/media/t*'
+OEmbed::Providers.register(osu_ms_provider)

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -193,6 +193,7 @@ en:
         save: Save
         title: Title
         ext_relation: External Resource
+        oembed_url: oEmbed URL
         edit_url: Edit URL
 
     notifications:

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -194,3 +194,8 @@ en:
         title: Title
         ext_relation: External Resource
         edit_url: Edit URL
+
+    notifications:
+      oembed_error:
+        message: 'The oEmbed URL attached to a work you deposited has encountered an error (either broken or non-allowlisted URI): %{messages}'
+        subject: 'Erroring oEmbed content'

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -89,6 +89,7 @@ en:
         time_required: "Time (in minutes) to complete the activity."
         typical_age_range: ""
         ext_relation: "To create a ScholarsArchive record that links to a work in another location, add an External Resource URL here. The location of that work must be reasonably stable, so a DOI or other persistent URL is strongly encouraged. Use one URL here or the files above, but not both."
+        oembed_url: "Add an oEmbed URL here. Use one URL here, one in external relation, or the files above, but not in all field."
       honors_college_thesis:
         contributor_advisor: "The name of the Academic Mentor on this project.<br>The name should be entered with the last name first, e.g. \"Smith, John Q.\"."
     labels:
@@ -170,5 +171,6 @@ en:
         typical_age_range: "Typical Age Range"
         visibility_after_embargo: "Then set it to"
         ext_relation: "External Resource"
+        oembed_url: "oEmbed URL"
       honors_college_thesis:
         contributor_advisor: "Mentor"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   mount Bulkrax::Engine, at: '/'
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
   mount BrowseEverything::Engine => '/browse'
+  mount Blacklight::Oembed::Engine => '/oembed'
 
   resources :other_options, only: [:destroy]
 

--- a/db/migrate/20260417215549_create_oembed_errors.rb
+++ b/db/migrate/20260417215549_create_oembed_errors.rb
@@ -1,0 +1,11 @@
+class CreateOembedErrors < ActiveRecord::Migration[5.2]
+  def change
+    create_table :oembed_errors do |t|
+      t.string :document_id
+      t.text :oembed_errors
+
+      t.timestamps
+    end
+    add_index :oembed_errors, :document_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -357,11 +357,11 @@ ActiveRecord::Schema.define(version: 2026_04_17_215549) do
   end
 
   create_table "oembed_errors", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
-    t.string "document_id", null: false
+    t.string "document_id"
     t.text "oembed_errors"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["document_id"], name: "index_oembed_errors_on_document_id"
+    t.index ["document_id"], name: "index_oembed_errors_on_document_id", unique: true
   end
 
   create_table "other_options", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_12_05_212513) do
+ActiveRecord::Schema.define(version: 2026_04_17_215549) do
 
   create_table "bookmarks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -354,6 +354,14 @@ ActiveRecord::Schema.define(version: 2024_12_05_212513) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["namespace"], name: "index_minter_states_on_namespace", unique: true
+  end
+
+  create_table "oembed_errors", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+    t.string "document_id", null: false
+    t.text "oembed_errors"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["document_id"], name: "index_oembed_errors_on_document_id"
   end
 
   create_table "other_options", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|

--- a/spec/controllers/hyrax/defaults_controller_spec.rb
+++ b/spec/controllers/hyrax/defaults_controller_spec.rb
@@ -11,5 +11,12 @@ RSpec.describe Hyrax::DefaultsController do
         expect(controller.attributes_for_actor[:ext_relation]).to eq [url]
       end
     end
+
+    context 'when an oembed_url is set in the params' do
+      it 'adds the url to the actor environment' do
+        controller.params = ActionController::Parameters.new({ oembed_url: [url] })
+        expect(controller.attributes_for_actor[:oembed_url]).to eq [url]
+      end
+    end
   end
 end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -26,4 +26,23 @@ RSpec.describe FileSet do
       expect(model.ext_relation?).to be true
     end
   end
+
+  # TEST NO.3: Testing to make sure the oembed url exist
+  describe 'oembed_url_metadata' do
+    it 'accepts oembed_url metadata' do
+      expect(model).to respond_to(:oembed_url)
+    end
+  end
+
+  # TEST NO.4: Test to make sure it can handle if the item has link or not
+  describe 'oembed_url' do
+    it 'returns false when an oembed_url is not present' do
+      expect(model.oembed_url?).to be false
+    end
+
+    it 'returns true when an oembed_url is present' do
+      model.oembed_url = url
+      expect(model.oembed_url?).to be true
+    end
+  end
 end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -26,23 +26,4 @@ RSpec.describe FileSet do
       expect(model.ext_relation?).to be true
     end
   end
-
-  # TEST NO.3: Testing to make sure the oembed url exist
-  describe 'oembed_url_metadata' do
-    it 'accepts oembed_url metadata' do
-      expect(model).to respond_to(:oembed_url)
-    end
-  end
-
-  # TEST NO.4: Test to make sure it can handle if the item has link or not
-  describe 'oembed_url' do
-    it 'returns false when an oembed_url is not present' do
-      expect(model.oembed_url?).to be false
-    end
-
-    it 'returns true when an oembed_url is present' do
-      model.oembed_url = url
-      expect(model.oembed_url?).to be true
-    end
-  end
 end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe FileSet do
   # TEST NO.4: Test to make sure it can handle if the item has link or not
   describe 'oembed_url' do
     it 'returns false when an oembed_url is not present' do
-      expect(model.oembed_url?).to be false
+      expect(model.oembed?).to be false
     end
 
     it 'returns true when an oembed_url is present' do
       model.oembed_url = url
-      expect(model.oembed_url?).to be true
+      expect(model.oembed?).to be true
     end
   end
 end

--- a/spec/models/oembed_error_spec.rb
+++ b/spec/models/oembed_error_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal:true
+
+require 'rails_helper'
+
+RSpec.describe OembedError, type: :model do
+  subject { model }
+
+  let(:model) { OembedError.new() }
+  let(:error1) { 'ERROR ERROR ERROR' }
+  let(:error2) { 'ERROR ERROR ERROR' }
+
+  before do
+    model.oembed_errors << error1
+    model.oembed_errors << error2
+  end
+
+  it { expect(model.oembed_errors).to be_an_instance_of(Array) }
+  it { expect(model.oembed_errors.count).to eq(2) }
+
+  it 'prevents error duplication' do
+    model.run_callbacks :save
+    expect(model.oembed_errors.count).to eq(1)
+  end
+end

--- a/spec/services/scholars_archive/oembed_error_service_spec.rb
+++ b/spec/services/scholars_archive/oembed_error_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal:true
+
+require 'rails_helper'
+
+RSpec.describe ScholarsArchive::OembedErrorService do
+  let(:depositor) do
+    User.create(email: 'test@example.com', guest: false) { |u| u.save!(validate: false) }
+  end
+  let(:audit_user) do
+    User.create(email: 'admin') { |u| u.save!(validate: false) }
+  end
+  let(:inbox) { depositor.mailbox.inbox }
+  let(:messages) { ['ERROR ERROR ERROR'] }
+
+  describe '#call' do
+    subject(:service) { described_class.new(depositor, messages) }
+
+    before do
+      allow(User).to receive(:audit_user).and_return(audit_user)
+      allow(User).to receive(:batch_user).and_return(audit_user)
+      service.call
+    end
+
+    it { expect(inbox.count).to eq(1) }
+
+    it 'sends error mail with the proper subject' do
+      inbox.each do |msg|
+        expect(msg.last_message.subject).to eq('Erroring oEmbed content')
+      end
+    end
+
+    it 'sends error mail with the proper message' do
+      inbox.each do |msg|
+        expect(msg.last_message.body).to include(messages.first)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`FEATURE:` Create an way to create FileSets using `:oembed_url` on top of File upload.

### Progression:
**Part #1:** _Add in as Fileset_
- [x] Setup predicate for `:oembed_url` as part of FileSet
- [x] Allow `edit` on form for this new predicate
- [x] Setup the field to appear on form for user (`.html.erb`)

**Part #2:** _Create the Actor_
- [x] Setup the actor needed for `:oembed_url`
- [x] Setup the connection to make sure the application can use `:oembed_url`
- [x] Create the `oembed_error` model and functionality needed for the actor (From porting over for OD2)
- [x] Update schema & DB
- [x] Add in `attribution` toward controller
- [x] Hook up the JS script to make sure it works with `:ext_relation`

**Part #3:** _Indexing & View_
- [x] Make sure to add in indexing to Solr & check to see if it is save correctly
- [x] Create necessary action to access via SolrDoc and others
- [x] Make sure the FileSet can be view and access from home page
- [x] Allow edit name & `:oembed_url` within FileSet
- [x] (Clarify) Need to embed the video as part of the thumbnail if listed first or add an icon

**Part #4:** _Spec & Others_
- [x] Create any specs needed and other items needed from the importing over
- [x] Create the `oembed_service` as a mailer to send out fail oembed