### PR TITLE
Locks down branding and adds flash notice

### DIFF
--- a/app/helpers/scholars_archive/collections_helper.rb
+++ b/app/helpers/scholars_archive/collections_helper.rb
@@ -1,0 +1,17 @@
+module ScholarsArchive
+  module CollectionsHelper
+    include Hyrax::CollectionsHelper
+
+    def collection_brandable?(collection:)
+      flash[:notice] = "To brand this collection, you must be an administrator. Please email through the contact form for branding assistance." unless current_user.admin?
+      case collection
+      when Valkyrie::Resource
+        CollectionType
+          .find_by_gid!(collection.collection_type_gid)
+          .brandable? && current_user.admin?
+      else
+        collection.try(:brandable?) && current_user.admin?
+      end
+    end
+  end
+end

--- a/app/helpers/scholars_archive/collections_helper.rb
+++ b/app/helpers/scholars_archive/collections_helper.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 module ScholarsArchive
+  # Helper method for collections. Locks down the ability to brand collections to only administrators.
   module CollectionsHelper
     include Hyrax::CollectionsHelper
 
     def collection_brandable?(collection:)
-      flash[:notice] = "To brand this collection, you must be an administrator. Please email through the contact form for branding assistance." unless current_user.admin?
+      flash[:notice] = 'To brand this collection, you must be an administrator. Please email through the contact form for branding assistance.' unless current_user.admin?
       case collection
       when Valkyrie::Resource
         CollectionType


### PR DESCRIPTION
<img width="1470" height="484" alt="Screenshot 2026-07-24 at 8 39 04 AM" src="https://github.com/user-attachments/assets/bee07e75-8a0f-4067-8c70-4a98cbc5bb76" />

Above is non-admin. Below is Admin.

<img width="1455" height="557" alt="Screenshot 2026-07-24 at 8 40 11 AM" src="https://github.com/user-attachments/assets/020bf785-f52d-4946-b8d2-db2c90578ced" />

Fixes #2916 